### PR TITLE
refactor: deprecate point_in_polygon in favour of a more generic contains

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ poly = [
     (0.4, 0.5), (0.7, 2.0), (5.3, 1.4), (4.0, -0.6)
 ]
 area_polygon(poly) # 7.855
-point_in_polygon((2.0, 0.5), poly) # true
-point_in_polygon((10.0, 10.0), poly) # false
+contains(poly, (2.0, 0.5)) # true
+contains(poly, (10.0, 10.0)) # false
 
 poly2 = [
     (3.0, 3.0), (4.0, 1.0), (3.0, 0.5), (2.0, -0.5), (1.5, 0.9)

--- a/src/PolygonAlgorithms.jl
+++ b/src/PolygonAlgorithms.jl
@@ -1,6 +1,6 @@
 module PolygonAlgorithms
 
-import Base: push!, insert!, iterate, merge!
+import Base: push!, insert!, iterate, merge!, contains
 import Base: length, show
 
 include("definitions.jl")
@@ -16,10 +16,11 @@ include("intersect_poly.jl")
 include("intersect_convex.jl")
 include("convex_hull.jl")
 
+include("deprecations.jl")
+
 export Point2D, Polygon2D, Segment2D, Line2D
 export get_orientation, Orientation, on_segment
 export area_polygon, first_moment, centroid_polygon, is_counter_clockwise, is_clockwise
-export point_in_polygon
 export do_intersect, intersect_geometry, intersect_edges
 export intersect_convex
 export convex_hull

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,1 @@
+@deprecate point_in_polygon(point, polygon; options...) contains(polygon, point; options...)

--- a/src/intersect_convex.jl
+++ b/src/intersect_convex.jl
@@ -37,9 +37,9 @@ function intersect_convex(polygon1::Polygon2D, polygon2::Polygon2D, ::PointSearc
     #https://www.swtestacademy.com/intersection-convex-polygons-algorithm/
     intersection_points = intersect_edges(polygon1, polygon2)
     
-    i1_in_2 = [point_in_polygon(p, polygon2) for p in polygon1]
+    i1_in_2 = [contains(polygon2, p) for p in polygon1]
     p1_in_2 = polygon1[i1_in_2]
-    i2_in_1 = [point_in_polygon(p, polygon1) for p in polygon2]
+    i2_in_1 = [contains(polygon1, p) for p in polygon2]
     p2_in_1 = polygon2[i2_in_1]
 
     if isempty(intersection_points) && isempty(p1_in_2) && isempty(p2_in_1)
@@ -102,9 +102,9 @@ function intersect_convex(polygon1::Polygon2D{T}, polygon2::Polygon2D{T}, ::Chas
         end
     end
     if isempty(points)
-        if point_in_polygon(polygon1[1], polygon2)
+        if contains(polygon2, polygon1[1])
             return polygon1
-        elseif  point_in_polygon(polygon2[1], polygon1)
+        elseif contains(polygon1, polygon2[1])
             return polygon2
         end
     end

--- a/src/intersect_poly.jl
+++ b/src/intersect_poly.jl
@@ -35,9 +35,9 @@ function intersect_geometry(polygon1::Polygon2D{T}, polygon2::Polygon2D{T}) wher
     if isempty(regions)
         p1 = get_first_non_intersection_point(list1)
         p2 = get_first_non_intersection_point(list2)
-        if point_in_polygon(p1, polygon2)
+        if contains(polygon2, p1)
             return [polygon1]
-        elseif point_in_polygon(p2, polygon1)
+        elseif contains(polygon1, p2)
             return [polygon2]
         end
     end

--- a/src/point_in_polygon.jl
+++ b/src/point_in_polygon.jl
@@ -1,7 +1,7 @@
 """
-    point_in_polygon(point, vertices)
+    contains(vertices, point; on_border_is_inside=true)
 
-Runs in `O(n)` time when `n=length(vertices)`.
+Runs in `O(n)` time where `n=length(vertices)`.
 
 This algorithm is an an extension of the odd-even ray algorithm.
 It is based on "A Simple and Correct Even-Odd Algorithm for the Point-in-Polygon Problem for Complex Polygons" 
@@ -9,7 +9,7 @@ by Michael Galetzka and Patrick Glauner (2017).
 It skips vertices that are on the ray. To compensate, the ray is projected backwards (to the left) so that an 
 intersection can be found for a skipped vertix if needed.
 """
-function point_in_polygon(point::Point2D{T}, vertices::Polygon2D; on_border_is_inside=true) where T
+function contains(vertices::Polygon2D, point::Point2D{T}; on_border_is_inside::Bool=true) where T
     n = length(vertices)
     num_intersections = 0
 

--- a/test/point_in_polygon.jl
+++ b/test/point_in_polygon.jl
@@ -93,67 +93,67 @@ skew_H = (
     )
 
 @testset "centre points" begin
-    @test point_in_polygon((5.0, 5.0), rectangle[1])
+    @test contains(rectangle[1], (5.0, 5.0),)
 
-    @test point_in_polygon((3.0, 8.0), H_polygon[1])
-    @test point_in_polygon((7.0, 8.0), H_polygon[1])
-    @test point_in_polygon((5.0, 5.0), H_polygon[1])
+    @test contains(H_polygon[1], (3.0, 8.0))
+    @test contains(H_polygon[1], (7.0, 8.0))
+    @test contains(H_polygon[1], (5.0, 5.0))
 
-    @test point_in_polygon((3.0, 7.0), L_polygon[1])
-    @test point_in_polygon((6.0, 2.0), L_polygon[1])
-    @test point_in_polygon((3.0, 2.0), L_polygon[1])
+    @test contains(L_polygon[1], (3.0, 7.0))
+    @test contains(L_polygon[1], (6.0, 2.0))
+    @test contains(L_polygon[1], (3.0, 2.0))
 
-    @test point_in_polygon((5.0, 5.0), pentagon[1])
-    @test point_in_polygon((5.0, 8.0), pentagon[1])
+    @test contains(pentagon[1], (5.0, 5.0))
+    @test contains(pentagon[1], (5.0, 8.0))
 end;
 
 @testset "outside points" begin
-    @test !point_in_polygon((5.0, 3.0), H_polygon[1])
-    @test !point_in_polygon((5.0, 8.0), H_polygon[1])
-    @test !point_in_polygon((1.0, 8.0), H_polygon[1])
+    @test !contains(H_polygon[1], (5.0, 3.0))
+    @test !contains(H_polygon[1], (5.0, 8.0))
+    @test !contains(H_polygon[1], (1.0, 8.0))
 
-    @test !point_in_polygon((8.0, 2.0), L_polygon[1])
-    @test !point_in_polygon((6.0, 8.0), L_polygon[1])
+    @test !contains(L_polygon[1], (8.0, 2.0))
+    @test !contains(L_polygon[1], (6.0, 8.0))
 
-    @test !point_in_polygon((5.0, 10.0), rectangle[1])
-    @test !point_in_polygon((1.0, 5.0), rectangle[1])
-    @test !point_in_polygon((10.0, 5.0), rectangle[1])
+    @test !contains(rectangle[1], (5.0, 10.0))
+    @test !contains(rectangle[1], (1.0, 5.0))
+    @test !contains(rectangle[1], (10.0, 5.0))
 
-    @test !point_in_polygon((2.0, 9.0), pentagon[1])
-    @test !point_in_polygon((8.0, 9.0), pentagon[1])
+    @test !contains(pentagon[1], (2.0, 9.0))
+    @test !contains(pentagon[1], (8.0, 9.0))
 end;
 
 @testset "horiztonal edges" begin
-    @test point_in_polygon((5.0, 6.0), H_polygon[1])
-    @test !point_in_polygon((5.0, 10.0), H_polygon[1])
-    @test point_in_polygon((3.0, 6.0), H_polygon[1])
+    @test contains(H_polygon[1], (5.0, 6.0))
+    @test !contains(H_polygon[1], (5.0, 10.0))
+    @test contains(H_polygon[1], (3.0, 6.0))
 
-    @test !point_in_polygon((8.0, 3.0), L_polygon[1])
-    @test point_in_polygon((3.0, 3.0), L_polygon[1])
-    @test point_in_polygon((6.0, 3.0), L_polygon[1])
+    @test !contains(L_polygon[1], (8.0, 3.0))
+    @test contains(L_polygon[1], (3.0, 3.0))
+    @test contains(L_polygon[1], (6.0, 3.0))
 
-    @test !point_in_polygon((5.0, 10.0), rectangle[1])
-    @test !point_in_polygon((1.0, 5.0), rectangle[1])
-    @test !point_in_polygon((10.0, 5.0), rectangle[1])
+    @test !contains(rectangle[1], (5.0, 10.0))
+    @test !contains(rectangle[1], (1.0, 5.0))
+    @test !contains(rectangle[1], (10.0, 5.0))
 
-    @test !point_in_polygon((1.0, 1.0), pentagon[1])
-    @test point_in_polygon((5.0, 1.0), pentagon[1])
+    @test !contains(pentagon[1], (1.0, 1.0))
+    @test contains(pentagon[1], (5.0, 1.0))
 
-    @test !point_in_polygon((1.0, 2.0), skew_H[1])
-    @test !point_in_polygon((5.0, 2.0), skew_H[1])
-    @test point_in_polygon((7.0, 2.0), skew_H[1])
+    @test !contains(skew_H[1], (1.0, 2.0))
+    @test !contains(skew_H[1], (5.0, 2.0))
+    @test contains(skew_H[1], (7.0, 2.0))
 end;
 
 @testset "vertix intersections" begin
-    @test !point_in_polygon((2.0, 10.0), pentagon[1])
-    @test point_in_polygon((5.0, 10.0), pentagon[1])
-    @test !point_in_polygon((8.0, 10.0), pentagon[1])
+    @test !contains(pentagon[1], (2.0, 10.0))
+    @test contains(pentagon[1], (5.0, 10.0))
+    @test !contains(pentagon[1], (8.0, 10.0))
 
-    @test !point_in_polygon((0.0, 7.0), pentagon[1])
-    @test point_in_polygon((1.0, 7.0), pentagon[1])
-    @test point_in_polygon((5.0, 7.0), pentagon[1])
-    @test point_in_polygon((9.0, 7.0), pentagon[1])
-    @test !point_in_polygon((10.0, 7.0), pentagon[1])
+    @test !contains(pentagon[1], (0.0, 7.0))
+    @test contains(pentagon[1], (1.0, 7.0))
+    @test contains(pentagon[1], (5.0, 7.0))
+    @test contains(pentagon[1], (9.0, 7.0))
+    @test !contains(pentagon[1], (10.0, 7.0))
 end;
 
 @testset "full grids" begin
@@ -168,7 +168,7 @@ end;
         grid_ =  BitArray(undef, 12, 11)
         for x in 0:10
             for y in 0:11
-                grid_[y + 1, x + 1] = point_in_polygon(float.((x, y)), polygon)
+                grid_[y + 1, x + 1] = contains(polygon, float.((x, y)))
             end
         end
         @test expected == grid_


### PR DESCRIPTION
Extend `Base.contains` to replace the function of `point_in_polygon`. Functionality remains the same.