### PR TITLE
Fix/point in polygon

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PolygonAlgorithms"
 uuid = "32a0d02f-32d9-4438-b5ed-3a2932b48f96"
 authors = ["Lior Sinai <sinailior@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [compat]
 julia = "1"

--- a/src/point_in_polygon.jl
+++ b/src/point_in_polygon.jl
@@ -7,7 +7,7 @@ This algorithm is an an extension of the odd-even ray algorithm.
 It is based on "A Simple and Correct Even-Odd Algorithm for the Point-in-Polygon Problem for Complex Polygons" 
 by Michael Galetzka and Patrick Glauner (2017). 
 It skips vertices that are on the ray. To compensate, the ray is projected backwards (to the left) so that an 
-intersection can be found for a skipped vertix if needed.
+intersection can be found for a skipped vertex if needed.
 
 `rtol` should be small because of the extreme points used in the algorithm.
 """
@@ -16,8 +16,8 @@ function contains(vertices::Polygon2D, point::Point2D{T}; on_border_is_inside::B
     num_intersections = 0
 
     x = x_coords(vertices)
-    extreme_left =  (minimum(x) - T(1e6), point[2])
-    extreme_right = (maximum(x) + T(1e6), point[2])
+    extreme_left =  (minimum(x) - T(1e3), point[2])
+    extreme_right = (maximum(x) + T(1e3), point[2])
 
     # step 1: point intersects a vertex or edge
     for i in 1:n
@@ -31,26 +31,27 @@ function contains(vertices::Polygon2D, point::Point2D{T}; on_border_is_inside::B
     # step 3: check intersections with vertices
     s = 1
     while s <= n
-        # step 2: find a vertix not on the same horizontal ray as the point
+        # step 2: find a vertex not on the same horizontal ray as the point
         while (s <= n) && (vertices[s][2] == point[2])
             s += 1
         end
         if s > n
             break
         end
-        # step 3a: find the next vertix not on the horizontal ray
+        # step 3a: find the next vertex not on the horizontal ray
         next_s = s
         skipped_right = false
         for i in 0:n
             next_s = (next_s) % n + 1
-            if vertices[next_s][2] != point[2]
+            if (vertices[next_s][2] != point[2]) && 
+                (vertices[s] != vertices[next_s]) # TODO tolerance
                 break
             end
             skipped_right = skipped_right || (vertices[next_s][1] > point[1])
         end
         # step 3b: edge intersect with the ray
         edge = (vertices[s], vertices[next_s])
-        intersect = 0
+        intersect = false
         if (next_s - s) == 1 || (s == n && next_s ==1) # 3b.i
             intersect = do_intersect(edge, (point, extreme_right); rtol=rtol)
         elseif skipped_right # 3b.ii

--- a/test/intersect_concave.jl
+++ b/test/intersect_concave.jl
@@ -22,7 +22,7 @@ using PolygonAlgorithms: translate, PointSet
     regions = intersect_geometry(poly2, poly1, alg)
     @test are_regions_equal(regions, expected)
 
-    # now vertix intersects edge
+    # now vertex intersects edge
     # creates cycle
     poly2_ = translate(poly2, (-1.0, 0.0))
     expected = (typeof(alg) == PolygonAlgorithms.MartinezRuedaAlg) ?
@@ -83,7 +83,7 @@ end
     @test are_regions_equal(regions, expected)
 end
 
-@testset "concave arrows vertix intercepts" begin 
+@testset "concave arrows vertex intercepts" begin 
     poly1 = [
         (-2.0, 2.0), (2.0, 2.0), (-1.0, 0.0), (-0.5, 1.5)
     ]
@@ -273,7 +273,7 @@ end
     @test are_regions_equal(regions, expected)
 end
 
-@testset "concave saw + vertix intercepts" begin 
+@testset "concave saw + vertex intercepts" begin 
     poly1 = [
         (0.0, 1.0), (0.0, 2.0), (3.0, 2.0), (3.0, 1.0)
     ]

--- a/test/intersect_convex.jl
+++ b/test/intersect_convex.jl
@@ -67,7 +67,7 @@ end
     points = intersect_convex(poly2, poly1, alg)
     @test PointSet(points) == PointSet(expected)
 
-    # edge + vertix overlap
+    # edge + vertex overlap
     poly2 = translate(poly1, (1.0, 0.0))
     expected = [
         (1.0, 2.0), (2.0, 2.0), (2.0, 0.0), (1.0, 0.0)
@@ -78,7 +78,7 @@ end
     @test PointSet(points) == PointSet(expected)
 end
 
-@testset "rectangles - vertix overlap" begin
+@testset "rectangles - vertex overlap" begin
     poly1 = [
         (0.0, 0.0), (0.0, 2.0), (2.0, 2.0), (2.0, 0.0)
     ]
@@ -93,7 +93,7 @@ end
     @test PointSet(points) == PointSet(expected)
 end
 
-@testset "edge intersect vertix inner" begin 
+@testset "edge intersect vertex inner" begin 
     poly1 = [
         (0.0, 0.0), (0.0, 3.0), (2.0, 5.0), (5.0, 0.0)
     ]
@@ -113,7 +113,7 @@ end
     @test PointSet(points) == PointSet(expected)
 end
 
-@testset "edge-vertix pass through" begin 
+@testset "edge-vertex pass through" begin 
     poly1 = [
         (0.0, 0.4),
         (0.3, 0.2),
@@ -142,7 +142,7 @@ end
     @test issetequal(answer, expected)
 end
 
-@testset "vertix intersect vertix" begin 
+@testset "vertex intersect vertex" begin 
     poly1 = [
         (0.0, 0.0), (0.0, 3.0), (2.0, 5.0), (5.0, 0.0)
     ]
@@ -162,7 +162,7 @@ end
     @test PointSet(points) == PointSet(expected)
 end
 
-@testset "vertix intersections" begin 
+@testset "vertex intersections" begin 
     poly1 = [
         (0.0, 0.0), (0.5, 1.0), (1.0, 0.0)
     ]
@@ -195,7 +195,7 @@ end
     @test PointSet(points) == PointSet(expected)
 end
 
-@testset "quads single vertix intersect" begin 
+@testset "quads single vertex intersect" begin 
     poly1 = [
         (1.0, 1.0), (2.0, 4.0), (5.0, 5.0), (4.0, 2.0)
     ]
@@ -276,7 +276,7 @@ end
     @test PointSet(points) == PointSet(expected)
 end
 
-@testset "multiple pockets + edge-vertix" begin 
+@testset "multiple pockets + edge-vertex" begin 
     poly1 = [
         (1.0, 3.0),
         (1.0, 5.5),

--- a/test/point_in_polygon.jl
+++ b/test/point_in_polygon.jl
@@ -144,7 +144,7 @@ end;
     @test contains(skew_H[1], (7.0, 2.0))
 end;
 
-@testset "vertix intersections" begin
+@testset "vertex intersections" begin
     @test !contains(pentagon[1], (2.0, 10.0))
     @test contains(pentagon[1], (5.0, 10.0))
     @test !contains(pentagon[1], (8.0, 10.0))


### PR DESCRIPTION
- Typo: Vertix -> vertex
- Point in polygon fixes:
  - Repeated points through the num_intersections count off, so skip them.
  - Make the extremes less extreme, to make the rtol more likely. Actually, these only need to be slightly bigger than the min and max. Even +-1 would suffice.
  - avoid the implicit type change by making intersect a boolean, until the addition