### PR TITLE
Fix/style

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PolygonAlgorithms"
 uuid = "32a0d02f-32d9-4438-b5ed-3a2932b48f96"
 authors = ["Lior Sinai <sinailior@gmail.com>"]
-version = "0.3.3"
+version = "0.3.4"
 
 [compat]
 julia = "1"

--- a/README.md
+++ b/README.md
@@ -43,48 +43,63 @@ idxs = vcat(1:length(poly), 1)
 plot(x_coords(poly, idxs), y_coords(poly, idxs))
 ```
 
-## Algorithms
+## Polygon Functions
 
 For all of the the following `n` and `m` are the number of vertices of the polygons.
 
-1. Area of polygon and centroid of polygon. 
-    - Shoe-lace formula.
-    - Time complexity: `O(n)`. 
+1. `area_polygon`, `centroid_polygon`, `first_moment`, `is_clockwise`, `is_counter_clockwise`
+    - Operations: area of polygon, centroid of polygon, polygon direction.
+    - Algorithm: Shoe-lace formula.
+    - Time complexity: `O(n)`.
     - Reference: [Wikipedia](https://en.wikipedia.org/wiki/Polygon#Area).
-2. Point in polygon.
-    - Ray casting with an extension from the following paper: "A Simple and Correct Even-Odd Algorithm for the Point-in-Polygon Problem for Complex Polygons" by Michael Galetzka and Patrick Glauner (2017).
+2. `bounds`
+    - Operation: bounding rectangle of a polygon.
+    - Algorithm: linear serach.
+    - Time complexity: `O(n)`.
+3. `contains`
+    - Operation: point in polygon.
+    - Algorithm: Ray casting with an extension from the following paper: "A Simple and Correct Even-Odd Algorithm for the Point-in-Polygon Problem for Complex Polygons" by Michael Galetzka and Patrick Glauner (2017).
     - Time complexity: `O(n)`. 
     - Reference: [Wikipedia](https://en.wikipedia.org/wiki/Point_in_polygon), [paper](https://arxiv.org/abs/1207.3502).
-3. Convex hull.
+4. `convex_hull`
+    - Operation: minimum convex hull around a set of points.
     - Gift-wrapping algorithm:
         - Time complexity: `O(nh)` where `h` is the number of points in the hull.
         - Reference: [Wikipedia](https://en.wikipedia.org/wiki/Gift_wrapping_algorithm).
     - Graham Scan algorithm:
         - Time complexity: `O(n*log(n))`.
-4. Intersection of polygons (polygon clipping). 
-    - Chasing edges algorithm:
+5. `intersect_convex`
+    - Operation: intersection of convex polygons (polygon clipping). 
+    - Chasing edges algorithm (default):
         - Convex only.
         - From "A New Linear Algorithm for Intersecting Convex Polygons" (1981) by Joseph O'Rourke et. al.
         - Time complexity: `O(n+m)`.
         - Reference: https://www.cs.jhu.edu/~misha/Spring16/ORourke82.pdf
-    - Point search algorithm:
+    -  Point search algorithm:
         - Convex only.
         - Combines point in polygon algorithm with intersection of edges.
         - Time complexity: `O(nm)`.
         - For general non-self-intersecting polygons, the intersection points are valid but the order is not.
-    - Martinez-Rueda algorithm:
-        - See point 5.
+    - Martinez-Rueda algorithm (default):
+        - See point 7.
+    - Weiler-Atherton algorithm:
+        - See point 6.
+6. `intersect_geometry`
+    - Operation: Intersection of polygons (polygon clipping).
+    - Martinez-Rueda algorithm (default).
+        - See point 6.
     - Weiler-Atherton algorithm:
         - Concave and convex but not self-intersecting.
         - Time complexity: `O(nm)`. 
         - For a full explanation, see my [blog post](https://liorsinai.github.io/mathematics/2023/09/30/polygon-clipping.html).
-5. Difference, intersection, union and XOR of polygons.
-    - Martinez-Rueda algorithm:
-        - Concave, convex and self-intersecting.
-        - Annotates each segments with 4 fill criteria: filled by itself above and/or below, and filled by the other polygon above and/or below. Once this has been accomplished, it is trivial to select segments which match the given operation.
-        - Time complexity: `O((n+m+k)log(n+m))`. 
-        - Reference: https://www.researchgate.net/publication/220163820_A_new_algorithm_for_computing_Boolean_operations_on_polygons
-        - Blog post: https://sean.fun/a/polygon-clipping-pt2/
+7. `difference_geometry`, `union_geometry`, `xor_geometry`
+    - Operation: boolean operations on polygons.
+    - Algorithm: Martinez-Rueda.
+    - Concave, convex and self-intersecting.
+    - Annotates each segments with 4 fill criteria: filled by itself above and/or below, and filled by the other polygon above and/or below. Once this has been accomplished, it is trivial to select segments which match the given operation.
+    - Time complexity: `O((n+m+k)log(n+m))`. 
+    - Reference: https://www.researchgate.net/publication/220163820_A_new_algorithm_for_computing_Boolean_operations_on_polygons
+    - Blog post: https://sean.fun/a/polygon-clipping-pt2/
     <p align="center">
     <img src="images/martinez_reuda.png" width="80%" style="padding:5px"/>
    </p>

--- a/src/boolean/martinez_rueda.jl
+++ b/src/boolean/martinez_rueda.jl
@@ -323,14 +323,27 @@ function find_transition(
     searchsortedfirst(list, event; lt=(x, y) -> is_above(x, y; atol=atol, rtol=rtol))
 end
 
+
+"""
+    is_above(event, other, [atol, rtol])
+
+
+!!!!! Critical function. May be source of errors that only emerge later.
+
+Return `true` if `event` is above `other`.
+
+A segment is considered above another if its start point is above the projection of the other segment.
+For symmetry, always project right most segment's start point on to the line 
+through the other segment and compare y values.
+- If `event` is to the right of `other`, its start point must be above the projection of `other`.
+- If `event` is to the left of `other`, `other` start point must be below the projection of `event`.
+
+Assumes segments always go left to right.
+"""
 function is_above(
     ev::SegmentEvent, other::SegmentEvent
     ; atol::AbstractFloat=1e-6, rtol::AbstractFloat=1e-4
     ) # statusCompare
-    # !!!!! Critical function. May be source of errors that only emerge later.
-    # Assumes segments always go left to right.
-    # For symmetry, always project right most segment's start point on to the line 
-    # through the other segment and compare y values.
     seg1 = ev.segment
     seg2 = other.segment
     ori_start = get_orientation(seg1[1], seg2[1], seg1[2]; rtol=rtol)

--- a/src/boolean/martinez_rueda.jl
+++ b/src/boolean/martinez_rueda.jl
@@ -330,13 +330,16 @@ end
 
 !!!!! Critical function. May be source of errors that only emerge later.
 
-Return `true` if `event` is above `other`.
+Return `true` if `event` is strictly above `other`.
 
-A segment is considered above another if its start point is above the projection of the other segment.
-For symmetry, always project right most segment's start point on to the line 
-through the other segment and compare y values.
-- If `event` is to the right of `other`, its start point must be above the projection of `other`.
-- If `event` is to the left of `other`, `other` start point must be below the projection of `event`.
+A segment is considered above another if:
+    1. It is to the left of the other segment.
+    2. And the start point of the other segment is orientated clockwise from it.
+    3. Or the segment is a vertical line and the end point in the other segment is lower than its top.
+Or symmetrically:
+    1. It is to the right of the other segment.
+    2. And its start point segment is orientated counter-clockwise from the other segment.
+    3. Or the other segment is a vertical line and the end point of this segment is higher than that top.
 
 Assumes segments always go left to right.
 """
@@ -346,14 +349,24 @@ function is_above(
     ) # statusCompare
     seg1 = ev.segment
     seg2 = other.segment
-    ori_start = get_orientation(seg1[1], seg2[1], seg1[2]; rtol=rtol)
-    if ori_start == COLINEAR
-        return !is_above_or_on(seg2[2], seg1)
-    end
-    if (seg2[1][1] < seg1[1][1])
-        is_above_or_on(seg1[1], seg2; atol=atol)
+    if (seg1[1][1] <= seg2[1][1])
+        if abs(seg1[2][1] - seg1[1][1]) <= atol # vertical segment
+            return seg2[2][2] < max(seg1[1][2], seg1[2][2]) # true if seg2 below seg1
+        end
+        orient = get_orientation(seg1[1], seg1[2], seg2[1]; rtol=rtol, atol=atol)
+        if orient == COLINEAR
+            orient = get_orientation(seg1[1], seg1[2], seg2[2]; rtol=rtol, atol=atol)
+        end
+        return orient == CLOCKWISE
     else
-        !is_above_or_on(seg2[1], seg1; atol=atol)
+        if abs(seg2[2][1] - seg2[1][1]) <= atol # vertical segment
+            return seg1[2][2] > max(seg2[1][2], seg2[2][2]) # true if seg1 above seg2
+        end
+        orient = get_orientation(seg2[1], seg2[2], seg1[1]; rtol=rtol, atol=atol)
+        if orient == COLINEAR
+            orient = get_orientation(seg2[1], seg2[2], seg1[2]; rtol=rtol, atol=atol)
+        end
+        return orient == COUNTER_CLOCKWISE
     end
 end
 

--- a/src/boolean/martinez_rueda.jl
+++ b/src/boolean/martinez_rueda.jl
@@ -73,21 +73,19 @@ end
 """
     martinez_rueda_algorithm(polygon1, polygon2, selection_criteria)
 
-The Martinez-Rueda-Feito polygon clipping algorithm.
+The Martínez-Rueda-Feito polygon clipping algorithm.
 Returns regions and edges of intersection.
 It runs in `O((n+m+k)log(n+m))` time where `n` and `m` are the number of vertices of `polygon1` 
-and `polygon2` respectively.
+and `polygon2` respectively and `k` is the total number of intersections between all segments.
 Use `intersect_convex` for convex polygons for an `O(n+m)` algorithm.
 
 Description:
-Operates at a segment level and is an extension of the Bentley-Ottman line intersection algorithm.
+- Operates at a segment level and is an extension of the Bentley-Ottman line intersection algorithm.
 Segments are scanned from left to right, bottom to top. 
-The key assumption is that intersections are only found between the segments above and
-below the current segment.
-(This makes the algorithm fast but also sensitive to determining these segments correctly.)
-In addition, the below segment is used to determine the fill annotations for the current segment 
-(or empty space if nothing is below it.)
-Once the annotations are done, it is trivial to pick out segments that match the given criteria.
+- The key assumption is that only the segments immediately above and below the current segment need to be inspected for intersections.
+This makes the algorithm fast but also sensitive to determining these segments correctly.
+- The segment that is immediately below (or empty space) is used to determine the fill annotations for the current segment.
+- Once all annotations are done, the desired segments can be selected that match a given criteria.
 
 Limitations
 1. It can fail for improper polygons: polygons with lines sticking out.
@@ -295,7 +293,8 @@ function event_loop!(
         else # event is ending, so remove it from the status
             idx = find_transition(sweep_status, head.other; atol=atol, rtol=rtol)
             if !(0 < idx <= length(sweep_status) && sweep_status[idx] === head.other)
-                @warn "Falling back to linear search through the sweep status. This might result in incorrect annotations and hence open chains."
+                @warn "$head was not in the expected location in the sweep status. " * 
+                    "Falling back to linear search. This might result in incorrect annotations and hence open chains."
                 idx = findfirst(x -> x === head.other, sweep_status)
                 @assert(
                     !isnothing(idx),

--- a/src/boolean/martinez_rueda.jl
+++ b/src/boolean/martinez_rueda.jl
@@ -637,6 +637,8 @@ Table
 16. Yes     Yes    Yes    Yes
 =#
 
+# For the 16 rows, indicate if (1) in the output shape (non-blank) and (2) which side is filled in that output shape
+
 INTERSECTION_CRITERIA = [
     BLANK, BLANK, BLANK, BLANK,
     BLANK, BELOW, EMPTY, BELOW,
@@ -645,7 +647,7 @@ INTERSECTION_CRITERIA = [
 ] # both below, both above, but not all 4
 
 INTERSECTION_SEGMENT_CRITERIA = [
-    BLANK, BLANK, ABOVE, BLANK,
+    BLANK, BLANK, BLANK, BLANK,
     BLANK, BLANK, EMPTY, BLANK,
     BLANK, EMPTY, BLANK, BLANK,
     BLANK, BLANK, BLANK, BLANK,
@@ -656,21 +658,21 @@ UNION_CRITERIA = [
     BELOW, BELOW, BLANK, BLANK,
     ABOVE, BLANK, ABOVE, BLANK,
     BLANK, BLANK, BLANK, BLANK,
-] # filled at once or twice on only 1 side
+] # filled only above/only below. (above1 | above2) ⊻ (below1 | below2)
 
 DIFFERENCE_CRITERIA = [
     BLANK, BLANK, BLANK, BLANK,
     BELOW, BLANK, BELOW, BLANK,
     ABOVE, ABOVE, BLANK, BLANK,
     BLANK, ABOVE, BELOW, BLANK,
-] # primary - secondary. 
+] # primary - secondary. (above1 && !above2) ⊻  (below1 && !below2)
 
 XOR_CRITERIA = [
     BLANK, BELOW, ABOVE, BLANK,
     BELOW, BLANK, BLANK, ABOVE,
     ABOVE, BLANK, BLANK, BELOW,
     BLANK, ABOVE, BELOW, BLANK,
-]
+] # (above1 ⊻ above2) ⊻ (below1 ⊻ below2)
 
 function apply_selection_criteria(annotated_segments::Vector{<:SegmentEvent{T}}, criteria::Vector{AnnotationFill}) where T
     result = SegmentEvent{T}[]

--- a/src/orientation.jl
+++ b/src/orientation.jl
@@ -128,11 +128,9 @@ In the general case, checks if the point `(xp, yp)` is above or on the line thro
 yp ≥ (y₂-y₁)/(x₂-x₁) * (xp-x₁) + y₁
 ```
 
-Note: it is possible that `yp>y₁` but the result is `false`. 
-For example, a point far to the left of `segment` where `segment` has a negative slope:
+This is equivalent to checking if the three points `((x₁, y₁), (x₂, y₂), (xp, yp))` are orientated counter-clockwise or are co-linear:
 ```
-  \\
- ̇  \\
+0  ≥ (y₂-y₁) * (xp-x₁) - (yp-y₁) * (x₂-x₁)
 ```
 
 In the special case of a vertical segment (`x₂=x₁`), this compares `y` values:

--- a/src/orientation.jl
+++ b/src/orientation.jl
@@ -140,11 +140,10 @@ In the special case of a vertical segment (`x₂=x₁`), this compares `y` value
 yp ≥ max(y₂, y₁)
 ```
 """
-function is_above_or_on(point::Point2D, segment::Segment2D; atol::AbstractFloat=1e-6)
+function is_above_or_on(point::Point2D, segment::Segment2D; atol::AbstractFloat=1e-6, rtol::AbstractFloat=1e-4)
     if abs(segment[2][1] - segment[1][1]) <= atol # vertical segment
         return point[2] >= max(segment[1][2], segment[2][2])
     end
-    cmp = (point[2] - segment[1][2]) * (segment[2][1] - segment[1][1]) - 
-          (segment[2][2] - segment[1][2]) * (point[1] - segment[1][1])
-    cmp >= 0.0
+    cmp = get_orientation(segment[1], segment[2], point; atol=atol, rtol=rtol)
+    cmp != CLOCKWISE # is counter-clockwise or co-linear
 end

--- a/src/orientation.jl
+++ b/src/orientation.jl
@@ -131,6 +131,7 @@ yp ≥ (y₂-y₁)/(x₂-x₁) * (xp-x₁) + y₁
 Note: it is possible that `yp>y₁` but the result is `false`. 
 For example, a point far to the left of `segment` where `segment` has a negative slope:
 ```
+  \\
  ̇  \\
 ```
 

--- a/src/polygon_boolean.jl
+++ b/src/polygon_boolean.jl
@@ -52,13 +52,11 @@ struct WeilerAthertonAlg <: PolygonIntersectionAlgorithm end
 - Returns regions and edges of interest. Does not return single points.
 - Works for convex and concave polygons including with holes and self-intersections.
 - Description: operates at a segment level and is an extension of the Bentley-Ottman line intersection algorithm.
-    Segments are scanned from left to right, bottom to top. 
-    The key assumption is that intersections are only found between the segments above and
-    below the current segment.
-    (This makes the algorithm fast but also sensitive to determining these segments correctly.)
-    In addition, the below segment (or empty space) is used to determine the fill annotations for 
-    the current segment.
-    Once the annotations are done, it is trivial to pick out segments that match the given criteria.
+    - Segments are scanned from left to right, bottom to top. 
+    - The key assumption is that only the segments immediately above and below the current segment need to be inspected for intersections.
+    This makes the algorithm fast but also sensitive to determining these segments correctly.
+    - The segment that is immediately below (or empty space) is used to determine the fill annotations for the current segment.
+    - Once all annotations are done, the desired segments can be selected that match a given criteria.
 - Limitations:
     1. It can fail for improper polygons: polygons with lines sticking out.
     2. It is sensitive to numeric inaccuracies e.g. a line that is almost vertical or 

--- a/test/convex_hull.jl
+++ b/test/convex_hull.jl
@@ -1,6 +1,8 @@
-@testset "convex hulls -$alg" for alg in [
-    PolygonAlgorithms.GiftWrappingAlg(),
-    PolygonAlgorithms.GrahamScanAlg(),
+using PolygonAlgorithms: GiftWrappingAlg, GrahamScanAlg
+
+@testset "convex hulls - $alg" for alg in [
+    GiftWrappingAlg(),
+    GrahamScanAlg(),
 ]
 
 @testset "convex hull rectangle" begin

--- a/test/intersect_concave.jl
+++ b/test/intersect_concave.jl
@@ -1,8 +1,9 @@
 using PolygonAlgorithms: translate, PointSet
+using PolygonAlgorithms: WeilerAthertonAlg, MartinezRuedaAlg
 
-@testset "intersect-concave $alg" for alg in [
-    PolygonAlgorithms.WeilerAthertonAlg(),
-    PolygonAlgorithms.MartinezRuedaAlg(),
+@testset "intersections concave - $alg" for alg in [
+    WeilerAthertonAlg(),
+    MartinezRuedaAlg(),
 ]
 
 @testset "rectangle jagged" begin 
@@ -165,8 +166,12 @@ end
 
 end
 
-@testset "intersect-concave only PolygonAlgorithms.WeilerAthertonAlg()" begin
-alg = PolygonAlgorithms.WeilerAthertonAlg()
+@testset "intersections concave - only WeilerAthertonAlg()" begin
+#=
+    The other algorithms can handle these cases, but may give slightly different results.
+    E.g. exclude line/point intersections.
+=#
+alg = WeilerAthertonAlg()
 
 @testset "concave outer share portion" begin 
     poly1 = [
@@ -358,8 +363,11 @@ end
 
 end
 
-@testset "intersect-concave only PolygonAlgorithms.MartinezRuedaAlg()" begin
-alg = PolygonAlgorithms.MartinezRuedaAlg()
+@testset "intersections concave - only MartinezRuedaAlg()" begin
+#=
+    Only the MartinezRuedaAlg can handle self intersecting polygons.
+=#
+alg = MartinezRuedaAlg()
 
 @testset "self-intersect rectangle" begin
     self_intersect = [

--- a/test/intersect_convex.jl
+++ b/test/intersect_convex.jl
@@ -1,10 +1,11 @@
 using PolygonAlgorithms: translate, PointSet
+using PolygonAlgorithms: PointSearchAlg, ChasingEdgesAlg, WeilerAthertonAlg, MartinezRuedaAlg
 
-@testset "convex intersections $alg" for alg in [
-    PolygonAlgorithms.PointSearchAlg(),
-    PolygonAlgorithms.ChasingEdgesAlg(),
-    PolygonAlgorithms.WeilerAthertonAlg(),
-    PolygonAlgorithms.MartinezRuedaAlg(), # Some results are different
+@testset "intersections convex - $alg" for alg in [
+    PointSearchAlg(),
+    ChasingEdgesAlg(),
+    WeilerAthertonAlg(),
+    MartinezRuedaAlg(), # Some results are different
 ]
 
 @testset "one inside the other" begin

--- a/test/martinez_rueda.jl
+++ b/test/martinez_rueda.jl
@@ -547,9 +547,9 @@ using PolygonAlgorithms: BLANK
 
         @testset "intersection" begin
             function is_intersect(above1, below1, above2, below2)
-                is_intersect = ((above1 & above2) | (below1 & below2))
-                is_intersect_segments = (above1 & below2) | (below1 & above2)
-                (is_intersect || is_intersect_segments) & !(above1 & above2 & below1 & below2)
+                is_intersect = ((above1 & above2) ⊻ (below1 & below2))
+                is_intersect_segments = (above1 & below2) ⊻ (below1 & above2)
+                (is_intersect || is_intersect_segments)
             end
 
             @test check_selection_criteria(
@@ -573,7 +573,7 @@ using PolygonAlgorithms: BLANK
 
         @testset "xor" begin
             @test check_selection_criteria(
-                (above1, below1, above2, below2) -> (above1 ⊻ above2)  ⊻ (below1 ⊻ below2),
+                (above1, below1, above2, below2) -> (above1 ⊻ above2) ⊻ (below1 ⊻ below2),
                 PolygonAlgorithms.XOR_CRITERIA
             )
         end

--- a/test/martinez_rueda.jl
+++ b/test/martinez_rueda.jl
@@ -4,542 +4,555 @@ using PolygonAlgorithms: add_annotated_segment!, compare_events, convert_to_even
 using PolygonAlgorithms: check_and_divide_intersection!, event_loop!, find_transition
 using PolygonAlgorithms: chain_segments
 
-@testset "Martinez-Rueda algorithm" begin
-    @testset "rectangle" begin
-        rectangle = [
-            (3.0, 3.0), (7.0, -1.0), (4.0, -4.0), (0.0, 0.0)
-        ]
-        event_queue = convert_to_event_queue(rectangle)
-        expected = [
-            SegmentEvent(((0.0, 0.0), (4.0, -4.0)), true),
-            SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true),
-            SegmentEvent(((0.0, 0.0), (3.0, 3.0)), false),
-            SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true),
-            SegmentEvent(((0.0, 0.0), (4.0, -4.0)), false),
-            SegmentEvent(((4.0, -4.0), (7.0, -1.0)), true),
-            SegmentEvent(((4.0, -4.0), (7.0, -1.0)), false),
-            SegmentEvent(((3.0, 3.0), (7.0, -1.0)), false),
-        ]
-        @test event_queue == expected
-    end
+@testset "Martinez-Rueda algorithm" verbose=true begin
 
-    @testset "vertical line" begin
-        triangle = [
-            (3.0, 3.0), (3.0, -4.0), (0.0, 0.0)
-        ]
-        event_queue = convert_to_event_queue(triangle)
-        expected = [
-            SegmentEvent(((0.0, 0.0), (3.0, -4.0)), true),
-            SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true),
-            SegmentEvent(((0.0, 0.0), (3.0, -4.0)), false),
-            SegmentEvent(((3.0, -4.0), (3.0, 3.0)), true),
-            SegmentEvent(((3.0, -4.0), (3.0, 3.0)), false),
-            SegmentEvent(((0.0, 0.0), (3.0, 3.0)), false),        
-        ]
-        @test event_queue == expected
+    @testset "queueing" begin
+        @testset "rectangle" begin
+            rectangle = [
+                (3.0, 3.0), (7.0, -1.0), (4.0, -4.0), (0.0, 0.0)
+            ]
+            event_queue = convert_to_event_queue(rectangle)
+            expected = [
+                SegmentEvent(((0.0, 0.0), (4.0, -4.0)), true),
+                SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true),
+                SegmentEvent(((0.0, 0.0), (3.0, 3.0)), false),
+                SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true),
+                SegmentEvent(((0.0, 0.0), (4.0, -4.0)), false),
+                SegmentEvent(((4.0, -4.0), (7.0, -1.0)), true),
+                SegmentEvent(((4.0, -4.0), (7.0, -1.0)), false),
+                SegmentEvent(((3.0, 3.0), (7.0, -1.0)), false),
+            ]
+            @test event_queue == expected
+        end
 
-        lowered_triangle = [
-            (3.0, 3.0), (3.0, -4.0), (0.0, -5.0)
-        ]
-        event_queue = convert_to_event_queue(lowered_triangle)
-        expected = [
-            SegmentEvent(((0.0, -5.0), (3.0, -4.0)), true),
-            SegmentEvent(((0.0, -5.0), (3.0, 3.0)), true),
-            SegmentEvent(((0.0, -5.0), (3.0, -4.0)), false),
-            SegmentEvent(((3.0, -4.0), (3.0, 3.0)), true),
-            SegmentEvent(((3.0, -4.0), (3.0, 3.0)), false),
-            SegmentEvent(((0.0, -5.0), (3.0, 3.0)), false),        
-        ]
-        @test event_queue == expected
+        @testset "vertical line" begin
+            triangle = [
+                (3.0, 3.0), (3.0, -4.0), (0.0, 0.0)
+            ]
+            event_queue = convert_to_event_queue(triangle)
+            expected = [
+                SegmentEvent(((0.0, 0.0), (3.0, -4.0)), true),
+                SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true),
+                SegmentEvent(((0.0, 0.0), (3.0, -4.0)), false),
+                SegmentEvent(((3.0, -4.0), (3.0, 3.0)), true),
+                SegmentEvent(((3.0, -4.0), (3.0, 3.0)), false),
+                SegmentEvent(((0.0, 0.0), (3.0, 3.0)), false),        
+            ]
+            @test event_queue == expected
 
-        mirror_triangle = [
-            (0.0, -4.0), (0.0, 3.0), (3.0, -5.0)
-        ]
-        event_queue = convert_to_event_queue(mirror_triangle)
-        expected = [
-            SegmentEvent(((0.0, -4.0), (3.0, -5.0)), true),   
-            SegmentEvent(((0.0, -4.0), (0.0, 3.0)), true),    
-            SegmentEvent(((0.0, -4.0), (0.0, 3.0)), false),   
-            SegmentEvent(((0.0, 3.0), (3.0, -5.0)), true),
-            SegmentEvent(((0.0, -4.0), (3.0, -5.0)), false),  
-            SegmentEvent(((0.0, 3.0), (3.0, -5.0)), false),        
-        ]
-        @test event_queue == expected
-    end
+            lowered_triangle = [
+                (3.0, 3.0), (3.0, -4.0), (0.0, -5.0)
+            ]
+            event_queue = convert_to_event_queue(lowered_triangle)
+            expected = [
+                SegmentEvent(((0.0, -5.0), (3.0, -4.0)), true),
+                SegmentEvent(((0.0, -5.0), (3.0, 3.0)), true),
+                SegmentEvent(((0.0, -5.0), (3.0, -4.0)), false),
+                SegmentEvent(((3.0, -4.0), (3.0, 3.0)), true),
+                SegmentEvent(((3.0, -4.0), (3.0, 3.0)), false),
+                SegmentEvent(((0.0, -5.0), (3.0, 3.0)), false),        
+            ]
+            @test event_queue == expected
 
-    @testset "almost vertical" begin
-        # the original segment was ((0.5345889348336309, 0.9626445530693036), (0.5346819812512368, 0.7153822809806809))
-        # it was not vertical, but the two intersecting lines make a tiny vertical segment
-        event_queue = [
-            SegmentEvent(((0.5346362515873916, 0.8369046444971744), (0.5346819812512368, 0.7153822809806809)), true),
-            SegmentEvent(((0.5346362515873916, 0.8369046444971744), (0.702057739662388, 0.63591526606886130)), true),
-            SegmentEvent(((0.5346358170779485, 0.8380593132624886), (0.5346362515873916, 0.8369046444971744)), true),
-            SegmentEvent(((0.5346358170779485, 0.8380593132624886), (0.6336845198791616, 0.7251516629897194)), true),
-        ]
-        # the event_loop! modified event_queue[3] with update_end!
-        # now, the tail should be inserted after it.
-        tail = SegmentEvent(event_queue[3].segment, false)
-        idx = searchsortedfirst(event_queue, tail; lt=compare_events)
-        @test_broken idx == 5
+            mirror_triangle = [
+                (0.0, -4.0), (0.0, 3.0), (3.0, -5.0)
+            ]
+            event_queue = convert_to_event_queue(mirror_triangle)
+            expected = [
+                SegmentEvent(((0.0, -4.0), (3.0, -5.0)), true),   
+                SegmentEvent(((0.0, -4.0), (0.0, 3.0)), true),    
+                SegmentEvent(((0.0, -4.0), (0.0, 3.0)), false),   
+                SegmentEvent(((0.0, 3.0), (3.0, -5.0)), true),
+                SegmentEvent(((0.0, -4.0), (3.0, -5.0)), false),  
+                SegmentEvent(((0.0, 3.0), (3.0, -5.0)), false),        
+            ]
+            @test event_queue == expected
+        end
+
+        @testset "almost vertical" begin
+            # the original segment was ((0.5345889348336309, 0.9626445530693036), (0.5346819812512368, 0.7153822809806809))
+            # it was not vertical, but the two intersecting lines make a tiny vertical segment
+            event_queue = [
+                SegmentEvent(((0.5346362515873916, 0.8369046444971744), (0.5346819812512368, 0.7153822809806809)), true),
+                SegmentEvent(((0.5346362515873916, 0.8369046444971744), (0.702057739662388, 0.63591526606886130)), true),
+                SegmentEvent(((0.5346358170779485, 0.8380593132624886), (0.5346362515873916, 0.8369046444971744)), true),
+                SegmentEvent(((0.5346358170779485, 0.8380593132624886), (0.6336845198791616, 0.7251516629897194)), true),
+            ]
+            # the event_loop! modified event_queue[3] with update_end!
+            # now, the tail should be inserted after it.
+            tail = SegmentEvent(event_queue[3].segment, false)
+            idx = searchsortedfirst(event_queue, tail; lt=compare_events)
+            @test_broken idx == 5
+        end
     end
 
     @testset "find_transitions" begin
-        # setup
-        status = [
-            SegmentEvent(((0.0, 5.0), (5.0, 5.0)), true),
-            SegmentEvent(((0.0, 3.0), (5.0, 3.0)), true),
-            SegmentEvent(((0.0, 1.0), (5.0, 1.0)), true),
-        ]
-        # test
-        ev6 = SegmentEvent(((0.0, 6.0), (5.0, 6.0)), true)
-        idx = find_transition(status, ev6)
-        @test idx == 1
-        ev34 = SegmentEvent(((0.0, 3.0), (5.0, 4.0)), true)
-        idx = find_transition(status, ev34)
-        @test idx == 2
-        ev32 = SegmentEvent(((0.0, 3.0), (5.0, 2.0)), true)
-        idx = find_transition(status, ev32)
-        @test idx == 3
-        ev2 = SegmentEvent(((0.0, 2.0), (5.0, 2.0)), true)
-        idx = find_transition(status, ev2)
-        @test idx == 3
-        ev0 = SegmentEvent(((0.0, 0.0), (5.0, 0.0)), true)
-        idx = find_transition(status, ev0)
-        @test idx == 4
-    end
-
-    @testset "sweep status head" begin
-        # setup
-        status = [SegmentEvent(((0.0, 5.0), (5.0, 5.0)), true)]
-        # test
-        ev6 = SegmentEvent(((0.0, 6.0), (5.0, 6.0)), true)
-        idx = find_transition(status, ev6)
-        @test idx == 1
-        ev2 = SegmentEvent(((0.0, 2.0), (5.0, 2.0)), true)
-        idx = find_transition(status, ev2)
-        @test idx == 2
-    end
-
-    @testset "sweep status rand lines" begin
-        # lines originally from the intersection of two randomly generated spiky polygon
-        segments = [
-            SegmentEvent(((0.5824, 0.5157), (0.9235, 0.39180)), true)
-            SegmentEvent(((0.5824, 0.5157), (0.9756, 0.3288)), true)
-            SegmentEvent(((0.5732, 0.7060), (0.7169, 0.6187)), true)
-            SegmentEvent(((0.5658, 0.6475), (0.6321, 0.6197)), true)
-            SegmentEvent(((0.5658, 0.6475), (0.7169, 0.6187)), true)
-            SegmentEvent(((0.5480, 0.9443), (0.7438, 0.6878)), true)
-            SegmentEvent(((0.5480, 0.9443), (0.7455, 0.8477)), true)
-            SegmentEvent(((0.5334, 0.9450), (0.7438, 0.6878)), true)
-            SegmentEvent(((0.5218, 0.2095), (0.5839, 0.1114)), true)
-            SegmentEvent(((0.5122, 0.9013), (0.6366, 0.9417)), true)
-            SegmentEvent(((0.4867, 0.5998), (0.6095, 0.6079)), true)
-            SegmentEvent(((0.4771, 0.4543), (0.5913, 0.4110)), true)
-            SegmentEvent(((0.4767, 0.5368), (0.6615, 0.5250)), true)
-            SegmentEvent(((0.4544, 0.0837), (0.6762, 0.4073)), true)
-            SegmentEvent(((0.4544, 0.0837), (0.7364, 0.3326)), true)
-            SegmentEvent(((0.4127, 0.4774), (0.6615, 0.5250)), true)
-        ]
-        sweep_status = SegmentEvent{Float64}[]
-        for event in segments
-            idx = find_transition(sweep_status, event)
-            insert!(sweep_status, idx, event)
+        @testset "horizontal lines" begin
+            # setup
+            status = [
+                SegmentEvent(((0.0, 5.0), (5.0, 5.0)), true),
+                SegmentEvent(((0.0, 3.0), (5.0, 3.0)), true),
+                SegmentEvent(((0.0, 1.0), (5.0, 1.0)), true),
+            ]
+            # test
+            ev6 = SegmentEvent(((0.0, 6.0), (5.0, 6.0)), true)
+            idx = find_transition(status, ev6)
+            @test idx == 1
+            ev34 = SegmentEvent(((0.0, 3.0), (5.0, 4.0)), true)
+            idx = find_transition(status, ev34)
+            @test idx == 2
+            ev32 = SegmentEvent(((0.0, 3.0), (5.0, 2.0)), true)
+            idx = find_transition(status, ev32)
+            @test idx == 3
+            ev2 = SegmentEvent(((0.0, 2.0), (5.0, 2.0)), true)
+            idx = find_transition(status, ev2)
+            @test idx == 3
+            ev0 = SegmentEvent(((0.0, 0.0), (5.0, 0.0)), true)
+            idx = find_transition(status, ev0)
+            @test idx == 4
         end
-        expected = [
-            SegmentEvent(((0.5480, 0.9443), (0.7455, 0.8477)), true),
-            SegmentEvent(((0.5480, 0.9443), (0.7438, 0.6878)), true),
-            SegmentEvent(((0.5334, 0.9450), (0.7438, 0.6878)), true),
-            SegmentEvent(((0.5122, 0.9013), (0.6366, 0.9417)), true),
-            SegmentEvent(((0.5732, 0.7060), (0.7169, 0.6187)), true),
-            SegmentEvent(((0.5658, 0.6475), (0.7169, 0.6187)), true),
-            SegmentEvent(((0.5658, 0.6475), (0.6321, 0.6197)), true),
-            SegmentEvent(((0.4867, 0.5998), (0.6095, 0.6079)), true),
-            SegmentEvent(((0.4767, 0.5368), (0.6615, 0.525)), true),
-            SegmentEvent(((0.5824, 0.5157), (0.9235, 0.3918)), true),
-            SegmentEvent(((0.5824, 0.5157), (0.9756, 0.3288)), true),
-            SegmentEvent(((0.4127, 0.4774), (0.6615, 0.525)), true),
-            SegmentEvent(((0.4771, 0.4543), (0.5913, 0.411)), true),
-            SegmentEvent(((0.5218, 0.2095), (0.5839, 0.1114)), true),
-            SegmentEvent(((0.4544, 0.0837), (0.6762, 0.4073)), true),
-            SegmentEvent(((0.4544, 0.0837), (0.7364, 0.3326)), true),
-        ]
-        @test sweep_status == expected
-    end
 
-    @testset "sweep status rand lines 2" begin
-        segments = [
-            SegmentEvent(((0.01190, 0.9843), (0.2696, 0.7221)), true),
-            SegmentEvent(((0.02439, 0.6210), (0.1274, 0.6140)), true),
-            SegmentEvent(((0.01190, 0.9843), (0.1166, 0.9564)), true),
-            SegmentEvent(((0.02706, 0.3861), (0.0599, 0.4676)), true),
-            SegmentEvent(((0.00284, 0.3700), (0.0727, 0.1129)), true),
-            SegmentEvent(((0.02201, 0.5214), (0.3929, 0.5001)), true),
-        ]
-        sweep_status = SegmentEvent{Float64}[]
-        for event in segments
-            idx = find_transition(sweep_status, event)
-            insert!(sweep_status, idx, event)
+        @testset "sweep status head" begin
+            # setup
+            status = [SegmentEvent(((0.0, 5.0), (5.0, 5.0)), true)]
+            # test
+            ev6 = SegmentEvent(((0.0, 6.0), (5.0, 6.0)), true)
+            idx = find_transition(status, ev6)
+            @test idx == 1
+            ev2 = SegmentEvent(((0.0, 2.0), (5.0, 2.0)), true)
+            idx = find_transition(status, ev2)
+            @test idx == 2
         end
-        expected =[
-            SegmentEvent(((0.0119, 0.9843), (0.1166, 0.9564)), true),
-            SegmentEvent(((0.0119, 0.9843), (0.2696, 0.7221)), true),
-            SegmentEvent(((0.02439, 0.621), (0.1274, 0.614)), true),
-            SegmentEvent(((0.02201, 0.5214), (0.3929, 0.5001)), true),
-            SegmentEvent(((0.02706, 0.3861), (0.0599, 0.4676)), true),
-            SegmentEvent(((0.00284, 0.37), (0.0727, 0.1129)), true),
-        ]
-        @test sweep_status == expected
     end
 
-    @testset "sweep status almost colinear" begin
-        sweep_status =[
-            SegmentEvent(((0.7481773880710287, 0.2525213105681051), (0.891378804016348, 0.0914800094089202)), true),
-            SegmentEvent(((0.7674956225378292, 0.19603318345420395), (0.93007516434479, 0.04850368886951295)), true),
-            SegmentEvent(((0.7307442328548945, 0.22237367849003833), (0.879152990839225, 0.03969376626137666)), true),
-            SegmentEvent(((0.7456555133038324, 0.17560361123176102), (0.879152990839225, 0.03969376626137666)), true)
-        ]
-        ev = SegmentEvent(((0.7692174020749689, 0.1749860342238233), (0.8076322984621129, 0.25945610393589347)), true)
-        # with rtol=1e-3, this is linear
-        idx = find_transition(sweep_status, ev)
-        @test idx == 4
-    end
-
-    @testset "sweep status steps" begin
-        # lines originally from the intersection of two randomly generated spiky polygon
-        segments = [
-            SegmentEvent(((0.0, 4.0), (3.0, 4.0)), true),
-            SegmentEvent(((0.0, 2.0), (3.0, 2.0)), true),
-            SegmentEvent(((3.0, 2.0), (3.0, -2.0)), true),
-            SegmentEvent(((3.0, -2.0), (6.0, -2.0)), true),
-            SegmentEvent(((3.0, -4.0), (6.0, -4.0)), true),
-        ]
-        sweep_status = SegmentEvent{Float64}[]
-        for event in segments
-            idx = find_transition(sweep_status, event)
-            insert!(sweep_status, idx, event)
+    @testset "order sweep status" begin
+        @testset "sweep status rand lines" begin
+            # lines originally from the intersection of two randomly generated spiky polygon
+            segments = [
+                SegmentEvent(((0.5824, 0.5157), (0.9235, 0.39180)), true)
+                SegmentEvent(((0.5824, 0.5157), (0.9756, 0.3288)), true)
+                SegmentEvent(((0.5732, 0.7060), (0.7169, 0.6187)), true)
+                SegmentEvent(((0.5658, 0.6475), (0.6321, 0.6197)), true)
+                SegmentEvent(((0.5658, 0.6475), (0.7169, 0.6187)), true)
+                SegmentEvent(((0.5480, 0.9443), (0.7438, 0.6878)), true)
+                SegmentEvent(((0.5480, 0.9443), (0.7455, 0.8477)), true)
+                SegmentEvent(((0.5334, 0.9450), (0.7438, 0.6878)), true)
+                SegmentEvent(((0.5218, 0.2095), (0.5839, 0.1114)), true)
+                SegmentEvent(((0.5122, 0.9013), (0.6366, 0.9417)), true)
+                SegmentEvent(((0.4867, 0.5998), (0.6095, 0.6079)), true)
+                SegmentEvent(((0.4771, 0.4543), (0.5913, 0.4110)), true)
+                SegmentEvent(((0.4767, 0.5368), (0.6615, 0.5250)), true)
+                SegmentEvent(((0.4544, 0.0837), (0.6762, 0.4073)), true)
+                SegmentEvent(((0.4544, 0.0837), (0.7364, 0.3326)), true)
+                SegmentEvent(((0.4127, 0.4774), (0.6615, 0.5250)), true)
+            ]
+            sweep_status = SegmentEvent{Float64}[]
+            for event in segments
+                idx = find_transition(sweep_status, event)
+                insert!(sweep_status, idx, event)
+            end
+            expected = [
+                SegmentEvent(((0.5480, 0.9443), (0.7455, 0.8477)), true),
+                SegmentEvent(((0.5480, 0.9443), (0.7438, 0.6878)), true),
+                SegmentEvent(((0.5334, 0.9450), (0.7438, 0.6878)), true),
+                SegmentEvent(((0.5122, 0.9013), (0.6366, 0.9417)), true),
+                SegmentEvent(((0.5732, 0.7060), (0.7169, 0.6187)), true),
+                SegmentEvent(((0.5658, 0.6475), (0.7169, 0.6187)), true),
+                SegmentEvent(((0.5658, 0.6475), (0.6321, 0.6197)), true),
+                SegmentEvent(((0.4867, 0.5998), (0.6095, 0.6079)), true),
+                SegmentEvent(((0.4767, 0.5368), (0.6615, 0.525)), true),
+                SegmentEvent(((0.5824, 0.5157), (0.9235, 0.3918)), true),
+                SegmentEvent(((0.5824, 0.5157), (0.9756, 0.3288)), true),
+                SegmentEvent(((0.4127, 0.4774), (0.6615, 0.525)), true),
+                SegmentEvent(((0.4771, 0.4543), (0.5913, 0.411)), true),
+                SegmentEvent(((0.5218, 0.2095), (0.5839, 0.1114)), true),
+                SegmentEvent(((0.4544, 0.0837), (0.6762, 0.4073)), true),
+                SegmentEvent(((0.4544, 0.0837), (0.7364, 0.3326)), true),
+            ]
+            @test sweep_status == expected
         end
-        expected = [
-            SegmentEvent(((0.0, 4.0), (3.0, 4.0)), true),
-            SegmentEvent(((0.0, 2.0), (3.0, 2.0)), true),
-            SegmentEvent(((3.0, 2.0), (3.0, -2.0)), true),
-            SegmentEvent(((3.0, -2.0), (6.0, -2.0)), true),
-            SegmentEvent(((3.0, -4.0), (6.0, -4.0)), true),
-        ]
-        @test sweep_status == expected
-    end
 
-    @testset "divide no intersection" begin
-        # setup
-        ev1_start = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true)
-        ev1_end = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), false)
-        ev1_start.other = ev1_end
-        ev1_end.other = ev1_start
-        ev2_start = SegmentEvent(((4.0, 5.0), (8.0, 3.0)), true)
-        ev2_end = SegmentEvent(((4.0, 5.0), (8.0, 3.0)), false)
-        ev2_start.other = ev2_end
-        ev2_end.other = ev2_start
-        queue = [ev1_start, ev2_start, ev1_end, ev2_end]
-        # test
-        check_and_divide_intersection!(queue, ev1_start, ev2_start, false)
-        @test length(queue) == 4
-    end
-
-    @testset "divide intersection" begin
-        # setup
-        ev1_start = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true)
-        ev1_end = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), false)
-        ev1_start.other = ev1_end
-        ev1_end.other = ev1_start
-        ev2_start = SegmentEvent(((4.0, 0.0), (7.0, 3.0)), true)
-        ev2_end = SegmentEvent(((4.0, 0.0), (7.0, 3.0)), false)
-        ev2_start.other = ev2_end
-        ev2_end.other = ev2_start
-        queue = [ev1_start, ev2_start, ev1_end, ev2_end]
-        # test
-        check_and_divide_intersection!(queue, ev1_start, ev2_start, false)
-        expected = [
-            ev1_start,
-            ev2_start,
-            ev2_end,
-            ev1_end,
-            SegmentEvent(((5.0, 1.0), (7.0, -1.0)), true),
-            SegmentEvent(((5.0, 1.0), (7.0, 3.0)), true),
-            SegmentEvent(((5.0, 1.0), (7.0, -1.0)), false),
-            SegmentEvent(((5.0, 1.0), (7.0, 3.0)), false),
-        ]
-        @test queue == expected
-    end
-
-    @testset "divide along1" begin
-        # setup
-        ev1_start = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true)
-        ev1_end = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), false)
-        ev1_start.other = ev1_end
-        ev1_end.other = ev1_start
-        ev2_start = SegmentEvent(((4.0, 2.0), (7.0, 5.0)), true)
-        ev2_end = SegmentEvent(((4.0, 2.0), (7.0, 5.0)), false)
-        ev2_start.other = ev2_end
-        ev2_end.other = ev2_start
-        queue = [ev1_start, ev2_start, ev1_end, ev2_end]
-        # test
-        check_and_divide_intersection!(queue, ev1_start, ev2_start, false)
-        expected = [
-            ev1_start,
-            ev1_end,
-            SegmentEvent(((4.0, 2.0), (7.0, -1.0)), true), 
-            ev2_start,
-            SegmentEvent(((4.0, 2.0), (7.0, -1.0)), false), 
-            ev2_end
-        ]
-        @test queue == expected
-    end
-
-    @testset "divide coincident" begin
-        # setup
-        ev1_start = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), true)
-        ev1_end = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), false)
-        ev1_start.other = ev1_end
-        ev1_end.other = ev1_start
-        ev2_start = SegmentEvent(((4.0, 2.0), (7.0, -1.0)), true)
-        ev2_end = SegmentEvent(((4.0, 2.0), (7.0, -1.0)), false)
-        ev2_start.other = ev2_end
-        ev2_end.other = ev2_start
-        queue = [ev1_start, ev2_start, ev1_end, ev2_end]
-        # test
-        check_and_divide_intersection!(queue, ev1_start, ev2_start, false)
-        @test length(queue) == 4 # no change because ev1 is processed before ev2
-        check_and_divide_intersection!(queue, ev2_start, ev1_start, false)
-        expected = [
-            ev1_start,
-            ev1_end,
-            SegmentEvent(((4.0, 2.0), (5.0, 1.0)), true),
-            ev2_start,
-            SegmentEvent(((4.0, 2.0), (5.0, 1.0)), false),
-            ev2_end,
-            SegmentEvent(((5.0, 1.0), (7.0, -1.0)), true),
-            SegmentEvent(((5.0, 1.0), (7.0, -1.0)), false),
-        ]
-        @test queue == expected
-    end
-
-    @testset "divide coincident same start" begin
-        # setup
-        ev1_start = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), true)
-        ev1_end = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), false)
-        ev1_start.other = ev1_end
-        ev1_end.other = ev1_start
-        primary = true
-        self_annotations = SegmentAnnotations(true, false)
-        ev2_start = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true, primary, self_annotations)
-        ev2_end = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), false, primary, self_annotations)
-        ev2_start.other = ev2_end
-        ev2_end.other = ev2_start
-        queue = [ev1_start, ev2_start, ev1_end, ev2_end]
-        # test
-        check_and_divide_intersection!(queue, ev1_start, ev2_start, true)
-        expected = [
-            ev2_start,
-            ev2_end,
-            SegmentEvent(((5.0, 1.0), (7.0, -1.0)), true, true, self_annotations),
-            SegmentEvent(((5.0, 1.0), (7.0, -1.0)), false, true, self_annotations),
-        ]
-        @test queue == expected
-    end
-
-    @testset "divide same intersection" begin
-        # setup
-        ev1_start = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), true)
-        ev1_end = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), false)
-        ev1_start.other = ev1_end
-        ev1_end.other = ev1_start
-        primary = true
-        self_annotations = SegmentAnnotations(true, false)
-        ev2_start = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), true, primary, self_annotations)
-        ev2_end = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), false, primary, self_annotations)
-        ev2_start.other = ev2_end
-        ev2_end.other = ev2_start
-        queue = [ev1_start, ev2_start, ev1_end, ev2_end]
-        # test
-        check_and_divide_intersection!(queue, ev1_start, ev2_start, true)
-        @test queue == [ev2_start, ev2_end]
-    end
-
-    @testset "rectangle self annotations" begin
-        rectangle = [
-            (3.0, 3.0), (7.0, -1.0), (4.0, -4.0), (0.0, 0.0)
-        ];
-        event_queue = convert_to_event_queue(rectangle)
-        annotated_segments = event_loop!(event_queue; self_intersection=true)
-        expected = [
-            SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((0.0, 0.0), (4.0, -4.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((4.0, -4.0), (7.0, -1.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true, true, SegmentAnnotations(false, true)),
-        ]
-        @test annotated_segments == expected
-    end
-
-    @testset "rectangle horiz self annotations" begin
-        rectangle_horiz = [
-            (-1.0, 0.0), (-1.0, 3.0), (12.0, 3.0), (12.0, 0.0)
-        ];
-        event_queue = convert_to_event_queue(rectangle_horiz)
-        annotated_segments = event_loop!(event_queue; self_intersection=true)
-        expected = [
-            SegmentEvent(((-1.0, 0.0), (-1.0, 3.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((-1.0, 0.0), (12.0, 0.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((12.0, 0.0), (12.0, 3.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((-1.0, 3.0), (12.0, 3.0)), true, true, SegmentAnnotations(false, true)),
-           
-        ]
-        @test annotated_segments == expected
-    end
-
-    @testset "self-intersect self annotations" begin
-        self_intersect = [
-            (0.0, 0.0), (2.0, 2.0), (6.0, -2.0), (11.0, 2.0), (11.0, 0.0)
-        ]
-        event_queue = convert_to_event_queue(self_intersect)
-        annotated_segments = event_loop!(event_queue; self_intersection=true)
-        expected = [
-            SegmentEvent(((0.0, 0.0), (2.0, 2.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((0.0, 0.0), (4.0, 0.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((2.0, 2.0), (4.0, 0.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((4.0, 0.0), (6.0, -2.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((6.0, -2.0), (8.5, -0.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((4.0, 0.0), (8.5, -0.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((8.5, -0.0), (11.0, 0.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((11.0, 0.0), (11.0, 2.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((8.5, -0.0), (11.0, 2.0)), true, true, SegmentAnnotations(false, true)),
-        ]
-        @test annotated_segments == expected
-    end
-
-    @testset "pentagram self annotations" begin
-        pentagon = [
-            (-0.8, 0.0), (0.0, 0.6), (0.8, 0.0), (0.5, -1.0), (-0.5, -1.0)
-        ]
-        pentagram = pentagon[[1, 3, 5, 2, 4]]
-        event_queue = convert_to_event_queue(pentagram)
-        annotated_segments = event_loop!(event_queue; self_intersection=true)
-        expected = [
-            SegmentEvent(((-0.5, -1.0), (-0.3062015503875969, -0.3798449612403101)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((-0.8, 0.0), (-0.3062015503875969, -0.3798449612403101)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((-0.3062015503875969, -0.3798449612403101), (-0.18750000000000003, 0.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((-0.8, 0.0), (-0.18750000000000003, 0.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((-0.5, -1.0), (-0.0, -0.6153846153846154)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((-0.3062015503875969, -0.3798449612403101), (-0.0, -0.6153846153846154)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((-0.18750000000000003, 0.0), (0.0, 0.6)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((-0.18750000000000003, 0.0), (0.1875, 0.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((0.0, 0.6), (0.1875, 0.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((-0.0, -0.6153846153846154), (0.30620155038759694, -0.3798449612403101)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((0.1875, 0.0), (0.30620155038759694, -0.3798449612403101)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((-0.0, -0.6153846153846154), (0.5, -1.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((0.30620155038759694, -0.3798449612403101), (0.5, -1.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((0.30620155038759694, -0.3798449612403101), (0.8, 0.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((0.1875, 0.0), (0.8, 0.0)), true, true, SegmentAnnotations(false, true)),
-        ]
-        @test annotated_segments == expected
-    end
-
-    @testset "rectangles intersect annotations" begin
-        rectangle = [
-            SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((0.0, 0.0), (4.0, -4.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((4.0, -4.0), (7.0, -1.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true, true, SegmentAnnotations(false, true)),
-        ]
-        rectangle_horiz = [
-            SegmentEvent(((-1.0, 0.0), (-1.0, 3.0)), true, false, SegmentAnnotations(false, true)),
-            SegmentEvent(((-1.0, 0.0), (12.0, 0.0)), true, false, SegmentAnnotations(true, false)),
-            SegmentEvent(((12.0, 0.0), (12.0, 3.0)), true, false, SegmentAnnotations(true, false)),
-            SegmentEvent(((-1.0, 3.0), (12.0, 3.0)), true, false, SegmentAnnotations(false, true)),
-        ]
-        queue = SegmentEvent{Float64}[]
-        for ev in vcat(rectangle, rectangle_horiz)
-            add_annotated_segment!(queue, ev)
+        @testset "sweep status rand lines 2" begin
+            segments = [
+                SegmentEvent(((0.01190, 0.9843), (0.2696, 0.7221)), true),
+                SegmentEvent(((0.02439, 0.6210), (0.1274, 0.6140)), true),
+                SegmentEvent(((0.01190, 0.9843), (0.1166, 0.9564)), true),
+                SegmentEvent(((0.02706, 0.3861), (0.0599, 0.4676)), true),
+                SegmentEvent(((0.00284, 0.3700), (0.0727, 0.1129)), true),
+                SegmentEvent(((0.02201, 0.5214), (0.3929, 0.5001)), true),
+            ]
+            sweep_status = SegmentEvent{Float64}[]
+            for event in segments
+                idx = find_transition(sweep_status, event)
+                insert!(sweep_status, idx, event)
+            end
+            expected =[
+                SegmentEvent(((0.0119, 0.9843), (0.1166, 0.9564)), true),
+                SegmentEvent(((0.0119, 0.9843), (0.2696, 0.7221)), true),
+                SegmentEvent(((0.02439, 0.621), (0.1274, 0.614)), true),
+                SegmentEvent(((0.02201, 0.5214), (0.3929, 0.5001)), true),
+                SegmentEvent(((0.02706, 0.3861), (0.0599, 0.4676)), true),
+                SegmentEvent(((0.00284, 0.37), (0.0727, 0.1129)), true),
+            ]
+            @test sweep_status == expected
         end
-        annotated_segments = event_loop!(queue; self_intersection=false)
-        expected = [
-            SegmentEvent(((-1.0, 0.0), (-1.0, 3.0)), true, false, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
-            SegmentEvent(((-1.0, 0.0), (0.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
-            SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(true, true)),
-            SegmentEvent(((-1.0, 3.0), (3.0, 3.0)), true, false, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
-            SegmentEvent(((0.0, 0.0), (4.0, -4.0)), true, true, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
-            SegmentEvent(((0.0, 0.0), (6.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(true, true)),
-            SegmentEvent(((3.0, 3.0), (6.0, 0.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(true, true)),
-            SegmentEvent(((4.0, -4.0), (7.0, -1.0)), true, true, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
-            SegmentEvent(((6.0, 0.0), (7.0, -1.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
-            SegmentEvent(((6.0, 0.0), (12.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
-            SegmentEvent(((12.0, 0.0), (12.0, 3.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
-            SegmentEvent(((3.0, 3.0), (12.0, 3.0)), true, false, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
-        ]
-        @test annotated_segments == expected
-    end
 
-    @testset "rectangle self-intersect annotations" begin
-        self_intersect = [
-            SegmentEvent(((0.0, 0.0), (2.0, 2.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((0.0, 0.0), (4.0, 0.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((2.0, 2.0), (4.0, 0.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((4.0, 0.0), (6.0, -2.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((6.0, -2.0), (8.5, -0.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((4.0, 0.0), (8.5, -0.0)), true, true, SegmentAnnotations(false, true)),
-            SegmentEvent(((8.5, -0.0), (11.0, 0.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((11.0, 0.0), (11.0, 2.0)), true, true, SegmentAnnotations(true, false)),
-            SegmentEvent(((8.5, -0.0), (11.0, 2.0)), true, true, SegmentAnnotations(false, true)),
-        ]
-        rectangle_horiz = [
-            SegmentEvent(((-1.0, 0.0), (-1.0, 3.0)), true, false, SegmentAnnotations(false, true)),
-            SegmentEvent(((-1.0, 0.0), (12.0, 0.0)), true, false, SegmentAnnotations(true, false)),
-            SegmentEvent(((12.0, 0.0), (12.0, 3.0)), true, false, SegmentAnnotations(true, false)),
-            SegmentEvent(((-1.0, 3.0), (12.0, 3.0)), true, false, SegmentAnnotations(false, true)),
-        ]
-        queue = SegmentEvent{Float64}[]
-        for ev in vcat(self_intersect, rectangle_horiz)
-            add_annotated_segment!(queue, ev)
+        @testset "sweep status almost colinear" begin
+            sweep_status =[
+                SegmentEvent(((0.7481773880710287, 0.2525213105681051), (0.891378804016348, 0.0914800094089202)), true),
+                SegmentEvent(((0.7674956225378292, 0.19603318345420395), (0.93007516434479, 0.04850368886951295)), true),
+                SegmentEvent(((0.7307442328548945, 0.22237367849003833), (0.879152990839225, 0.03969376626137666)), true),
+                SegmentEvent(((0.7456555133038324, 0.17560361123176102), (0.879152990839225, 0.03969376626137666)), true)
+            ]
+            ev = SegmentEvent(((0.7692174020749689, 0.1749860342238233), (0.8076322984621129, 0.25945610393589347)), true)
+            # with rtol=1e-3, this is linear
+            idx = find_transition(sweep_status, ev)
+            @test idx == 4
         end
-        annotated_segments = event_loop!(queue; self_intersection=false)
-        expected = [
-            SegmentEvent(((-1.0, 0.0), (-1.0, 3.0)), true, false, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
-            SegmentEvent(((-1.0, 0.0), (0.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
-            SegmentEvent(((0.0, 0.0), (2.0, 2.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(true, true)),
-            SegmentEvent(((0.0, 0.0), (4.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(true, false)),
-            SegmentEvent(((2.0, 2.0), (4.0, 0.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(true, true)),
-            SegmentEvent(((4.0, 0.0), (6.0, -2.0)), true, true, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
-            SegmentEvent(((6.0, -2.0), (8.5, -0.0)), true, true, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
-            SegmentEvent(((4.0, 0.0), (8.5, -0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, true)),
-            SegmentEvent(((8.5, -0.0), (11.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(true, false)),
-            SegmentEvent(((11.0, 0.0), (11.0, 2.0)), true, true, SegmentAnnotations(true, false), SegmentAnnotations(true, true)),
-            SegmentEvent(((8.5, -0.0), (11.0, 2.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(true, true)),
-            SegmentEvent(((11.0, 0.0), (12.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
-            SegmentEvent(((12.0, 0.0), (12.0, 3.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
-            SegmentEvent(((-1.0, 3.0), (12.0, 3.0)), true, false, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
-        ]
-        @test annotated_segments == expected
+
+        @testset "sweep status steps" begin
+            # lines originally from the intersection of two randomly generated spiky polygon
+            segments = [
+                SegmentEvent(((0.0, 4.0), (3.0, 4.0)), true),
+                SegmentEvent(((0.0, 2.0), (3.0, 2.0)), true),
+                SegmentEvent(((3.0, 2.0), (3.0, -2.0)), true),
+                SegmentEvent(((3.0, -2.0), (6.0, -2.0)), true),
+                SegmentEvent(((3.0, -4.0), (6.0, -4.0)), true),
+            ]
+            sweep_status = SegmentEvent{Float64}[]
+            for event in segments
+                idx = find_transition(sweep_status, event)
+                insert!(sweep_status, idx, event)
+            end
+            expected = [
+                SegmentEvent(((0.0, 4.0), (3.0, 4.0)), true),
+                SegmentEvent(((0.0, 2.0), (3.0, 2.0)), true),
+                SegmentEvent(((3.0, 2.0), (3.0, -2.0)), true),
+                SegmentEvent(((3.0, -2.0), (6.0, -2.0)), true),
+                SegmentEvent(((3.0, -4.0), (6.0, -4.0)), true),
+            ]
+            @test sweep_status == expected
+        end
     end
 
-    @testset "chain segments - rectangle" begin
-        segments = [
-            SegmentEvent(((0.0, 0.0), (4.0, -4.0)), true),
-            SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true),
-            SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true),
-            SegmentEvent(((4.0, -4.0), (7.0, -1.0)), true),
-        ]
-        regions = chain_segments(segments)
-        expected = [[(7.0, -1.0), (3.0, 3.0), (0.0, 0.0), (4.0, -4.0)]]
-        @test regions == expected
+    @testset "divide" begin
+        @testset "divide no intersection" begin
+            # setup
+            ev1_start = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true)
+            ev1_end = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), false)
+            ev1_start.other = ev1_end
+            ev1_end.other = ev1_start
+            ev2_start = SegmentEvent(((4.0, 5.0), (8.0, 3.0)), true)
+            ev2_end = SegmentEvent(((4.0, 5.0), (8.0, 3.0)), false)
+            ev2_start.other = ev2_end
+            ev2_end.other = ev2_start
+            queue = [ev1_start, ev2_start, ev1_end, ev2_end]
+            # test
+            check_and_divide_intersection!(queue, ev1_start, ev2_start, false)
+            @test length(queue) == 4
+        end
+
+        @testset "divide intersection" begin
+            # setup
+            ev1_start = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true)
+            ev1_end = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), false)
+            ev1_start.other = ev1_end
+            ev1_end.other = ev1_start
+            ev2_start = SegmentEvent(((4.0, 0.0), (7.0, 3.0)), true)
+            ev2_end = SegmentEvent(((4.0, 0.0), (7.0, 3.0)), false)
+            ev2_start.other = ev2_end
+            ev2_end.other = ev2_start
+            queue = [ev1_start, ev2_start, ev1_end, ev2_end]
+            # test
+            check_and_divide_intersection!(queue, ev1_start, ev2_start, false)
+            expected = [
+                ev1_start,
+                ev2_start,
+                ev2_end,
+                ev1_end,
+                SegmentEvent(((5.0, 1.0), (7.0, -1.0)), true),
+                SegmentEvent(((5.0, 1.0), (7.0, 3.0)), true),
+                SegmentEvent(((5.0, 1.0), (7.0, -1.0)), false),
+                SegmentEvent(((5.0, 1.0), (7.0, 3.0)), false),
+            ]
+            @test queue == expected
+        end
+
+        @testset "divide along1" begin
+            # setup
+            ev1_start = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true)
+            ev1_end = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), false)
+            ev1_start.other = ev1_end
+            ev1_end.other = ev1_start
+            ev2_start = SegmentEvent(((4.0, 2.0), (7.0, 5.0)), true)
+            ev2_end = SegmentEvent(((4.0, 2.0), (7.0, 5.0)), false)
+            ev2_start.other = ev2_end
+            ev2_end.other = ev2_start
+            queue = [ev1_start, ev2_start, ev1_end, ev2_end]
+            # test
+            check_and_divide_intersection!(queue, ev1_start, ev2_start, false)
+            expected = [
+                ev1_start,
+                ev1_end,
+                SegmentEvent(((4.0, 2.0), (7.0, -1.0)), true), 
+                ev2_start,
+                SegmentEvent(((4.0, 2.0), (7.0, -1.0)), false), 
+                ev2_end
+            ]
+            @test queue == expected
+        end
+
+        @testset "divide coincident" begin
+            # setup
+            ev1_start = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), true)
+            ev1_end = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), false)
+            ev1_start.other = ev1_end
+            ev1_end.other = ev1_start
+            ev2_start = SegmentEvent(((4.0, 2.0), (7.0, -1.0)), true)
+            ev2_end = SegmentEvent(((4.0, 2.0), (7.0, -1.0)), false)
+            ev2_start.other = ev2_end
+            ev2_end.other = ev2_start
+            queue = [ev1_start, ev2_start, ev1_end, ev2_end]
+            # test
+            check_and_divide_intersection!(queue, ev1_start, ev2_start, false)
+            @test length(queue) == 4 # no change because ev1 is processed before ev2
+            check_and_divide_intersection!(queue, ev2_start, ev1_start, false)
+            expected = [
+                ev1_start,
+                ev1_end,
+                SegmentEvent(((4.0, 2.0), (5.0, 1.0)), true),
+                ev2_start,
+                SegmentEvent(((4.0, 2.0), (5.0, 1.0)), false),
+                ev2_end,
+                SegmentEvent(((5.0, 1.0), (7.0, -1.0)), true),
+                SegmentEvent(((5.0, 1.0), (7.0, -1.0)), false),
+            ]
+            @test queue == expected
+        end
+
+        @testset "divide coincident same start" begin
+            # setup
+            ev1_start = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), true)
+            ev1_end = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), false)
+            ev1_start.other = ev1_end
+            ev1_end.other = ev1_start
+            primary = true
+            self_annotations = SegmentAnnotations(true, false)
+            ev2_start = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true, primary, self_annotations)
+            ev2_end = SegmentEvent(((3.0, 3.0), (7.0, -1.0)), false, primary, self_annotations)
+            ev2_start.other = ev2_end
+            ev2_end.other = ev2_start
+            queue = [ev1_start, ev2_start, ev1_end, ev2_end]
+            # test
+            check_and_divide_intersection!(queue, ev1_start, ev2_start, true)
+            expected = [
+                ev2_start,
+                ev2_end,
+                SegmentEvent(((5.0, 1.0), (7.0, -1.0)), true, true, self_annotations),
+                SegmentEvent(((5.0, 1.0), (7.0, -1.0)), false, true, self_annotations),
+            ]
+            @test queue == expected
+        end
+
+        @testset "divide same intersection" begin
+            # setup
+            ev1_start = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), true)
+            ev1_end = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), false)
+            ev1_start.other = ev1_end
+            ev1_end.other = ev1_start
+            primary = true
+            self_annotations = SegmentAnnotations(true, false)
+            ev2_start = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), true, primary, self_annotations)
+            ev2_end = SegmentEvent(((3.0, 3.0), (5.0, 1.0)), false, primary, self_annotations)
+            ev2_start.other = ev2_end
+            ev2_end.other = ev2_start
+            queue = [ev1_start, ev2_start, ev1_end, ev2_end]
+            # test
+            check_and_divide_intersection!(queue, ev1_start, ev2_start, true)
+            @test queue == [ev2_start, ev2_end]
+        end
     end
 
-    @testset "chain segments - improper" begin
-        segments = [
-            SegmentEvent(((0.0, 0.0), (2.0, 2.0)), true),
-            SegmentEvent(((0.0, 0.0), (2.0, 2.0)), true),
-            SegmentEvent(((2.0, 2.0), (5.0, 1.0)), true),
-            SegmentEvent(((2.0, 2.0), (3.0, 5.0)), true),
-            SegmentEvent(((3.0, 5.0), (5.0, 1.0)), true),
-        ]
-        expected = [(0.0, 0.0), (2.0, 2.0), (3.0, 5.0), (5.0, 1.0), (2.0, 2.0)]
-        @test_throws AssertionError chain_segments(segments)
+    @testset "annotations" begin
+        @testset "rectangle self annotations" begin
+            rectangle = [
+                (3.0, 3.0), (7.0, -1.0), (4.0, -4.0), (0.0, 0.0)
+            ];
+            event_queue = convert_to_event_queue(rectangle)
+            annotated_segments = event_loop!(event_queue; self_intersection=true)
+            expected = [
+                SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((0.0, 0.0), (4.0, -4.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((4.0, -4.0), (7.0, -1.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true, true, SegmentAnnotations(false, true)),
+            ]
+            @test annotated_segments == expected
+        end
+
+        @testset "rectangle horiz self annotations" begin
+            rectangle_horiz = [
+                (-1.0, 0.0), (-1.0, 3.0), (12.0, 3.0), (12.0, 0.0)
+            ];
+            event_queue = convert_to_event_queue(rectangle_horiz)
+            annotated_segments = event_loop!(event_queue; self_intersection=true)
+            expected = [
+                SegmentEvent(((-1.0, 0.0), (-1.0, 3.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((-1.0, 0.0), (12.0, 0.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((12.0, 0.0), (12.0, 3.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((-1.0, 3.0), (12.0, 3.0)), true, true, SegmentAnnotations(false, true)),
+            
+            ]
+            @test annotated_segments == expected
+        end
+
+        @testset "self-intersect self annotations" begin
+            self_intersect = [
+                (0.0, 0.0), (2.0, 2.0), (6.0, -2.0), (11.0, 2.0), (11.0, 0.0)
+            ]
+            event_queue = convert_to_event_queue(self_intersect)
+            annotated_segments = event_loop!(event_queue; self_intersection=true)
+            expected = [
+                SegmentEvent(((0.0, 0.0), (2.0, 2.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((0.0, 0.0), (4.0, 0.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((2.0, 2.0), (4.0, 0.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((4.0, 0.0), (6.0, -2.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((6.0, -2.0), (8.5, -0.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((4.0, 0.0), (8.5, -0.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((8.5, -0.0), (11.0, 0.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((11.0, 0.0), (11.0, 2.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((8.5, -0.0), (11.0, 2.0)), true, true, SegmentAnnotations(false, true)),
+            ]
+            @test annotated_segments == expected
+        end
+
+        @testset "pentagram self annotations" begin
+            pentagon = [
+                (-0.8, 0.0), (0.0, 0.6), (0.8, 0.0), (0.5, -1.0), (-0.5, -1.0)
+            ]
+            pentagram = pentagon[[1, 3, 5, 2, 4]]
+            event_queue = convert_to_event_queue(pentagram)
+            annotated_segments = event_loop!(event_queue; self_intersection=true)
+            expected = [
+                SegmentEvent(((-0.5, -1.0), (-0.3062015503875969, -0.3798449612403101)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((-0.8, 0.0), (-0.3062015503875969, -0.3798449612403101)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((-0.3062015503875969, -0.3798449612403101), (-0.18750000000000003, 0.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((-0.8, 0.0), (-0.18750000000000003, 0.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((-0.5, -1.0), (-0.0, -0.6153846153846154)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((-0.3062015503875969, -0.3798449612403101), (-0.0, -0.6153846153846154)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((-0.18750000000000003, 0.0), (0.0, 0.6)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((-0.18750000000000003, 0.0), (0.1875, 0.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((0.0, 0.6), (0.1875, 0.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((-0.0, -0.6153846153846154), (0.30620155038759694, -0.3798449612403101)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((0.1875, 0.0), (0.30620155038759694, -0.3798449612403101)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((-0.0, -0.6153846153846154), (0.5, -1.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((0.30620155038759694, -0.3798449612403101), (0.5, -1.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((0.30620155038759694, -0.3798449612403101), (0.8, 0.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((0.1875, 0.0), (0.8, 0.0)), true, true, SegmentAnnotations(false, true)),
+            ]
+            @test annotated_segments == expected
+        end
+
+        @testset "rectangles intersect annotations" begin
+            rectangle = [
+                SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((0.0, 0.0), (4.0, -4.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((4.0, -4.0), (7.0, -1.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true, true, SegmentAnnotations(false, true)),
+            ]
+            rectangle_horiz = [
+                SegmentEvent(((-1.0, 0.0), (-1.0, 3.0)), true, false, SegmentAnnotations(false, true)),
+                SegmentEvent(((-1.0, 0.0), (12.0, 0.0)), true, false, SegmentAnnotations(true, false)),
+                SegmentEvent(((12.0, 0.0), (12.0, 3.0)), true, false, SegmentAnnotations(true, false)),
+                SegmentEvent(((-1.0, 3.0), (12.0, 3.0)), true, false, SegmentAnnotations(false, true)),
+            ]
+            queue = SegmentEvent{Float64}[]
+            for ev in vcat(rectangle, rectangle_horiz)
+                add_annotated_segment!(queue, ev)
+            end
+            annotated_segments = event_loop!(queue; self_intersection=false)
+            expected = [
+                SegmentEvent(((-1.0, 0.0), (-1.0, 3.0)), true, false, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
+                SegmentEvent(((-1.0, 0.0), (0.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
+                SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(true, true)),
+                SegmentEvent(((-1.0, 3.0), (3.0, 3.0)), true, false, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
+                SegmentEvent(((0.0, 0.0), (4.0, -4.0)), true, true, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
+                SegmentEvent(((0.0, 0.0), (6.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(true, true)),
+                SegmentEvent(((3.0, 3.0), (6.0, 0.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(true, true)),
+                SegmentEvent(((4.0, -4.0), (7.0, -1.0)), true, true, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
+                SegmentEvent(((6.0, 0.0), (7.0, -1.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
+                SegmentEvent(((6.0, 0.0), (12.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
+                SegmentEvent(((12.0, 0.0), (12.0, 3.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
+                SegmentEvent(((3.0, 3.0), (12.0, 3.0)), true, false, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
+            ]
+            @test annotated_segments == expected
+        end
+
+        @testset "rectangle self-intersect annotations" begin
+            self_intersect = [
+                SegmentEvent(((0.0, 0.0), (2.0, 2.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((0.0, 0.0), (4.0, 0.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((2.0, 2.0), (4.0, 0.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((4.0, 0.0), (6.0, -2.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((6.0, -2.0), (8.5, -0.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((4.0, 0.0), (8.5, -0.0)), true, true, SegmentAnnotations(false, true)),
+                SegmentEvent(((8.5, -0.0), (11.0, 0.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((11.0, 0.0), (11.0, 2.0)), true, true, SegmentAnnotations(true, false)),
+                SegmentEvent(((8.5, -0.0), (11.0, 2.0)), true, true, SegmentAnnotations(false, true)),
+            ]
+            rectangle_horiz = [
+                SegmentEvent(((-1.0, 0.0), (-1.0, 3.0)), true, false, SegmentAnnotations(false, true)),
+                SegmentEvent(((-1.0, 0.0), (12.0, 0.0)), true, false, SegmentAnnotations(true, false)),
+                SegmentEvent(((12.0, 0.0), (12.0, 3.0)), true, false, SegmentAnnotations(true, false)),
+                SegmentEvent(((-1.0, 3.0), (12.0, 3.0)), true, false, SegmentAnnotations(false, true)),
+            ]
+            queue = SegmentEvent{Float64}[]
+            for ev in vcat(self_intersect, rectangle_horiz)
+                add_annotated_segment!(queue, ev)
+            end
+            annotated_segments = event_loop!(queue; self_intersection=false)
+            expected = [
+                SegmentEvent(((-1.0, 0.0), (-1.0, 3.0)), true, false, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
+                SegmentEvent(((-1.0, 0.0), (0.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
+                SegmentEvent(((0.0, 0.0), (2.0, 2.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(true, true)),
+                SegmentEvent(((0.0, 0.0), (4.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(true, false)),
+                SegmentEvent(((2.0, 2.0), (4.0, 0.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(true, true)),
+                SegmentEvent(((4.0, 0.0), (6.0, -2.0)), true, true, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
+                SegmentEvent(((6.0, -2.0), (8.5, -0.0)), true, true, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
+                SegmentEvent(((4.0, 0.0), (8.5, -0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, true)),
+                SegmentEvent(((8.5, -0.0), (11.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(true, false)),
+                SegmentEvent(((11.0, 0.0), (11.0, 2.0)), true, true, SegmentAnnotations(true, false), SegmentAnnotations(true, true)),
+                SegmentEvent(((8.5, -0.0), (11.0, 2.0)), true, true, SegmentAnnotations(false, true), SegmentAnnotations(true, true)),
+                SegmentEvent(((11.0, 0.0), (12.0, 0.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
+                SegmentEvent(((12.0, 0.0), (12.0, 3.0)), true, false, SegmentAnnotations(true, false), SegmentAnnotations(false, false)),
+                SegmentEvent(((-1.0, 3.0), (12.0, 3.0)), true, false, SegmentAnnotations(false, true), SegmentAnnotations(false, false)),
+            ]
+            @test annotated_segments == expected
+        end
+    end
+
+    @testset "chain segments" begin
+        @testset "chain segments - rectangle" begin
+            segments = [
+                SegmentEvent(((0.0, 0.0), (4.0, -4.0)), true),
+                SegmentEvent(((0.0, 0.0), (3.0, 3.0)), true),
+                SegmentEvent(((3.0, 3.0), (7.0, -1.0)), true),
+                SegmentEvent(((4.0, -4.0), (7.0, -1.0)), true),
+            ]
+            regions = chain_segments(segments)
+            expected = [[(7.0, -1.0), (3.0, 3.0), (0.0, 0.0), (4.0, -4.0)]]
+            @test regions == expected
+        end
+
+        @testset "chain segments - improper" begin
+            segments = [
+                SegmentEvent(((0.0, 0.0), (2.0, 2.0)), true),
+                SegmentEvent(((0.0, 0.0), (2.0, 2.0)), true),
+                SegmentEvent(((2.0, 2.0), (5.0, 1.0)), true),
+                SegmentEvent(((2.0, 2.0), (3.0, 5.0)), true),
+                SegmentEvent(((3.0, 5.0), (5.0, 1.0)), true),
+            ]
+            expected = [(0.0, 0.0), (2.0, 2.0), (3.0, 5.0), (5.0, 1.0), (2.0, 2.0)]
+            @test_throws AssertionError chain_segments(segments)
+        end
     end
 end


### PR DESCRIPTION
- update comments.
- refactor tests. Add tests for selection_criteria.
- update readme: order by Polygon functions and add to descriptions.
- refactor: use orientation directly in `is_above` calculation. This has the advantage of only requiring one calculation instead of 2, unless segments are co-linear - which will happen for connected edges of a polygon - then it requires 2.