### PR TITLE
Fix/is above

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PolygonAlgorithms"
 uuid = "32a0d02f-32d9-4438-b5ed-3a2932b48f96"
 authors = ["Lior Sinai <sinailior@gmail.com>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [compat]
 julia = "1.2"

--- a/README.md
+++ b/README.md
@@ -106,11 +106,10 @@ For all of the the following `n` and `m` are the number of vertices of the polyg
 
 ## Installation
 
-Download the GitHub repository (it is not registered). Then in the Julia REPL:
+In the Julia REPL:
 ```
 julia> ] #enter package mode
-(@v1.x) pkg> dev path\\to\\PolygonAlgorithms
-julia> using Revise # allows dynamic edits to code
+(@v1.x) pkg> add PolygonAlgorithms
 julia> using PolygonAlgorithms
 ```
 

--- a/src/boolean/martinez_rueda.jl
+++ b/src/boolean/martinez_rueda.jl
@@ -322,7 +322,6 @@ function find_transition(
     searchsortedfirst(list, event; lt=(x, y) -> is_above(x, y; atol=atol, rtol=rtol))
 end
 
-
 """
     is_above(event, other, [atol, rtol])
 
@@ -334,11 +333,9 @@ Return `true` if `event` is strictly above `other`.
 A segment is considered above another if:
     1. It is to the left of the other segment.
     2. And the start point of the other segment is orientated clockwise from it.
-    3. Or the segment is a vertical line and the end point in the other segment is lower than its top.
 Or symmetrically:
-    1. It is to the right of the other segment.
-    2. And its start point segment is orientated counter-clockwise from the other segment.
-    3. Or the other segment is a vertical line and the end point of this segment is higher than that top.
+    1. It is in line or to the right of the other segment.
+    2. And its start point is orientated counter-clockwise from the other segment.
 
 Assumes segments always go left to right.
 """
@@ -348,19 +345,13 @@ function is_above(
     ) # statusCompare
     seg1 = ev.segment
     seg2 = other.segment
-    if (seg1[1][1] <= seg2[1][1])
-        if abs(seg1[2][1] - seg1[1][1]) <= atol # vertical segment
-            return seg2[2][2] < max(seg1[1][2], seg1[2][2]) # true if seg2 below seg1
-        end
+    if (seg1[1][1] < seg2[1][1])
         orient = get_orientation(seg1[1], seg1[2], seg2[1]; rtol=rtol, atol=atol)
         if orient == COLINEAR
             orient = get_orientation(seg1[1], seg1[2], seg2[2]; rtol=rtol, atol=atol)
         end
         return orient == CLOCKWISE
     else
-        if abs(seg2[2][1] - seg2[1][1]) <= atol # vertical segment
-            return seg1[2][2] > max(seg2[1][2], seg2[2][2]) # true if seg1 above seg2
-        end
         orient = get_orientation(seg2[1], seg2[2], seg1[1]; rtol=rtol, atol=atol)
         if orient == COLINEAR
             orient = get_orientation(seg2[1], seg2[2], seg1[2]; rtol=rtol, atol=atol)

--- a/src/boolean/martinez_rueda.jl
+++ b/src/boolean/martinez_rueda.jl
@@ -293,7 +293,7 @@ function event_loop!(
         else # event is ending, so remove it from the status
             idx = find_transition(sweep_status, head.other; atol=atol, rtol=rtol)
             if !(0 < idx <= length(sweep_status) && sweep_status[idx] === head.other)
-                @warn "$head was not in the expected location in the sweep status. " * 
+                @warn "$(head.other) was not in the expected location in the sweep status. " * 
                     "Falling back to linear search. This might result in incorrect annotations and hence open chains."
                 idx = findfirst(x -> x === head.other, sweep_status)
                 @assert(

--- a/src/orientation.jl
+++ b/src/orientation.jl
@@ -5,9 +5,8 @@
 
 Determine orientation of three points. 
 
-Colinear is returned if `cross(pq, qr) <= tol`, where `tol` is the 
-- `atol` if either magnitude is less than `atol`.
-- `rtol * |pq||qr|` otherwise, where `cross(pq, qr) ≈ |pq||qr|θ` for small `θ`.
+Colinear is returned if `cross(pq, qr) <= atol`.
+The relative tolerance `rtol` is no longer used and will be removed in the future.
 
 Clockwise is returned if `cross(pq, qr)` is positive, else counter-clockwise.
 """
@@ -15,10 +14,7 @@ function get_orientation(p::Point2D, q::Point2D, r::Point2D; rtol::AbstractFloat
     pq = (q[1] - p[1], q[2] - p[2])
     qr = (r[1] - q[1], r[2] - q[2])
     cross_product = pq[2] * qr[1] - qr[2] * pq[1]
-    mag_pq = sqrt(pq[1] * pq[1] + pq[2] * pq[2])
-    mag_qr = sqrt(qr[1] * qr[1] + qr[2] * qr[2])
-    tol = (mag_qr >= atol && mag_pq >= atol) ? (mag_pq * mag_qr) * rtol : atol
-    orientation = abs(cross_product) <= tol ? COLINEAR : 
+    orientation = abs(cross_product) <= atol ? COLINEAR : 
         cross_product >= 0 ?  CLOCKWISE : 
         COUNTER_CLOCKWISE
     orientation

--- a/test/martinez_rueda.jl
+++ b/test/martinez_rueda.jl
@@ -124,6 +124,17 @@ using PolygonAlgorithms: BLANK
             idx = find_transition(status, ev2)
             @test idx == 2
         end
+
+        @testset "size discrepancy" begin
+            # from spiral-star example. 
+            status = [
+                SegmentEvent(((-10.0, -12.0), (0.0, -2.0)), true) # star leg
+            ]
+            # test
+            ev = SegmentEvent(((-8.338, -10.337), (-8.239, -10.426)), true) # tiny segment of spiral
+            idx = find_transition(status, ev)
+            @test idx == 1
+        end
     end
 
     @testset "order sweep status" begin


### PR DESCRIPTION
Small fixes:
- fix: don't use `rtol` in `get_orientation` because it can fail when there is a large size discrepancy. This was encountered in the examples/polygon_boolean.jl script with the star and spiral.
- fix: is_above doesn't need to do a vertical line check. See issue #19.
- fix: wrong event printed in the warning.

Also, update installation notes because this package is registered.